### PR TITLE
Avoid moclojer.helpers namespace.

### DIFF
--- a/dev/moclojer/build.clj
+++ b/dev/moclojer/build.clj
@@ -2,12 +2,15 @@
   (:require [clojure.data.json :as json]
             [clojure.java.io :as io]
             [clojure.string :as string]
-            [clojure.tools.build.api :as b]
-            [moclojer.helper :as helper]))
+            [clojure.tools.build.api :as b]))
 
 (def lib 'moclojer/moclojer)
 (def class-dir "target/classes")
 (def uber-file "target/moclojer.jar")
+(def moclojer-version
+  "moclojer version rendering constant"
+  "0.1")
+
 (set! *warn-on-reflection* true)
 
 (defn -main
@@ -16,7 +19,7 @@
     (b/delete {:path "target"})
     (b/write-pom {:class-dir class-dir
                   :lib       lib
-                  :version   helper/moclojer-version
+                  :version   moclojer-version
                   :basis     basis
                   :src-dirs  (:paths basis)})
     (b/compile-clj {:basis     basis

--- a/src/moclojer/core.clj
+++ b/src/moclojer/core.clj
@@ -4,12 +4,12 @@
             [clojure.java.io :as io]
             [io.pedestal.http :as http]
             [io.pedestal.http.jetty]
-            [moclojer.helper :as helper]
             [moclojer.router :as router])
   (:import (java.nio.file Files LinkOption)
            (java.nio.file.attribute BasicFileAttributes)
            (org.eclipse.jetty.server.handler.gzip GzipHandler)
-           (org.eclipse.jetty.servlet ServletContextHandler)))
+           (org.eclipse.jetty.servlet ServletContextHandler)
+           (java.util Properties)))
 
 (defn context-configurator
   [^ServletContextHandler context]
@@ -62,10 +62,19 @@
                                    (not= new old))
                                  file-state))}))
 
+(def *pom-info
+  (delay
+    (let [p (Properties.)]
+      (some-> "META-INF/maven/moclojer/moclojer/pom.properties"
+        io/resource
+        io/reader
+        (->> (.load p)))
+      p)))
+
 (defn -main
   "start moclojer server"
   [& _]
-  (prn (list '-> 'moclojer :start-server :version helper/moclojer-version))
+  (prn (list '-> 'moclojer :start-server :version (get @*pom-info "version")))
   (let [config (System/getenv "CONFIG")
         mocks (System/getenv "MOCKS")
         env {::router/config (or config "moclojer.yml")

--- a/src/moclojer/helper.clj
+++ b/src/moclojer/helper.clj
@@ -1,5 +1,0 @@
-(ns moclojer.helper)
-
-(def moclojer-version
-  "moclojer version rendering constant"
-  "0.1")


### PR DESCRIPTION
We can get the version directly form the POM.