### PR TITLE
Adds Command Line Interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,10 +20,10 @@ pom.xml.asc
 /moclojer
 !test/moclojer/resources/
 !.devcontainer
-*.yaml
-*.yml
-*.edn
-*.json
+moclojer.yaml
+moclojer.yml
+moclojer.edn
+moclojer.json
 *.org
 .socket-repl-port
 upload-filesystem/

--- a/README.md
+++ b/README.md
@@ -54,6 +54,23 @@ bash < <(curl -s https://raw.githubusercontent.com/moclojer/moclojer/main/instal
 ```
 > If you are using Linux you maybe need `sudo`.
 
+## CLI Usage
+`clj -M:run [OPTIONS]`, `java -jar moclojer.jar [OPTIONS]` and `moclojer_Linux [OPTIONS]`
+
+### Options
+
+#### -c, --config <file>
+Config path <file> or the CONFIG environment variable. [Default: moclojer.yml]
+
+#### -m, --mocks <file>
+OpenAPI v3 mocks path <file> or the MOCKS environment variable.
+
+#### -h, --help
+Show help information
+
+#### -v, --version
+Show version information
+
 ## 💻 dev environment
 
 We use git submodule for integration with the [**OpenAPI v3** specification](https://github.com/OAI/OpenAPI-Specification), you need to update the git submodule code.
@@ -65,7 +82,7 @@ git submodule update -f --init
 ### run
 
 ```sh
-clj -X:run
+clj -M:run
 ```
 
 ### test

--- a/deps.edn
+++ b/deps.edn
@@ -4,6 +4,7 @@
            io.pedestal/pedestal.jetty   {:mvn/version "0.5.10"}
            io.pedestal/pedestal.route   {:mvn/version "0.5.10"}
            io.pedestal/pedestal.service {:mvn/version "0.5.10"}
+           org.babashka/cli             {:mvn/version "0.4.37"}
            org.clojure/clojure          {:mvn/version "1.11.1"}
            org.clojure/core.async       {:mvn/version "1.5.648"}
            org.clojure/data.json        {:mvn/version "2.4.0"}
@@ -11,8 +12,8 @@
            selmer/selmer                {:mvn/version "1.12.52"}}
  :aliases {;; Run project
            ;; clj -X:run
-           :run       {:ns-default moclojer.core
-                       :exec-fn    moclojer.core/-main}
+           :run  {:main-opts ["-m" "babashka.cli.exec"]
+                  :exec-fn    moclojer.core/-main}
            ;; clj -A:dev -m moclojer.core
            :dev      {:extra-paths ["dev"]
                       :extra-deps  {io.github.clojure/tools.build {:git/url    "https://github.com/clojure/tools.build.git"

--- a/src/moclojer/adapters.clj
+++ b/src/moclojer/adapters.clj
@@ -1,0 +1,10 @@
+(ns moclojer.adapters)
+
+(defn inputs->config
+  [{:keys [args opts]} envs current-version]
+  (let [{:keys [c config m mocks v version h help]} (first args)]
+    {:current-version current-version
+     :config (or c config (:config envs) (:config opts))
+     :mocks (or m mocks (:mocks envs) (:mocks opts))
+     :version (or v version (:version opts))
+     :help (or h help (:help opts))}))

--- a/src/moclojer/core.clj
+++ b/src/moclojer/core.clj
@@ -98,11 +98,11 @@
         http/start)))
 
 (def spec {:config {:ref          "<file>"
-                    :desc         "Config path <file> or the CONFIG enviroment variable."
+                    :desc         "Config path <file> or the CONFIG environment variable."
                     :alias        :c
                     :default      "moclojer.yml"}
            :mocks  {:ref          "<file>"
-                    :desc         "OpenAPI v3 mocks path <file> or the MOCKS enviroment variable."
+                    :desc         "OpenAPI v3 mocks path <file> or the MOCKS environment variable."
                     :alias        :m}
            :version {:desc        "Show version."
                      :alias       :v}

--- a/src/moclojer/core.clj
+++ b/src/moclojer/core.clj
@@ -111,16 +111,16 @@
 
 (defn -main
   "start moclojer server"
-  {:org.babashka/cli {:collect {:args []}}}
-  [& args]
+  {:org.babashka/cli {}}
+  [& main-args]
   (let [current-version (or (get @*pom-info "version") "dev")
-        {:keys [args opts]} (cli/parse-args args {:spec spec})
+        {:keys [args opts]} (cli/parse-args main-args {:spec spec})
         {:keys [c config m mocks v version h help]} (first args)
         args-map {:current-version current-version
                   :config (or c config (System/getenv "CONFIG") (:config opts))
                   :mocks (or m mocks (System/getenv "MOCKS") (:mocks opts))
-                  :version (or v version)
-                  :help (or h help)}]
+                  :version (or v version (:version opts))
+                  :help (or h help (:help opts))}]
 
     (when (:version args-map)
       (println "moclojer" current-version)
@@ -128,7 +128,7 @@
 
     (when (:help args-map)
       (println
-        (str "Moclojer (" current-version "), simple and efficient HTTP mock server.\n\r"
+        (str "Moclojer (" current-version "), simple and efficient HTTP mock server.\r\n"
              (cli/format-opts {:spec spec :order [:config :mocks :version :help]})))
       (System/exit 0))
 

--- a/test/moclojer/adapters_test.clj
+++ b/test/moclojer/adapters_test.clj
@@ -1,0 +1,59 @@
+(ns moclojer.adapters-test
+  (:require [clojure.test :refer [are deftest testing]]
+            [moclojer.adapters :as adapters]))
+
+(deftest inputs-config-test
+  (testing "inputs->config can read data from all data sources"
+    (are [result inputs] (= result inputs)
+
+      {:current-version "dev"
+       :config "config.yaml"
+       :mocks "mocks.yaml"
+       :version true
+       :help true}
+      (adapters/inputs->config {:args [{:config "config.yaml"
+                                        :mocks "mocks.yaml"
+                                        :version true
+                                        :help true}]
+                                :opts {:config "opts-config.yaml"
+                                       :mocks "opts-mocks.yaml"}}
+                               {:config "default-config.yaml"
+                                :mocks "default-mocks.yaml"}
+                               "dev")
+
+      {:current-version "dev"
+       :config "opts-config.yaml"
+       :mocks "opts-mocks.yaml"
+       :version true
+       :help true}
+      (adapters/inputs->config {:args []
+                                :opts {:config "opts-config.yaml"
+                                       :mocks "opts-mocks.yaml"
+                                       :version true
+                                       :help true}}
+                               {}
+                               "dev")
+
+      {:current-version "dev"
+       :config "env-config.yaml"
+       :mocks "env-mocks.yaml"
+       :version true
+       :help true}
+      (adapters/inputs->config {:args [{:version true
+                                        :help true}]
+                                :opts {:config "opts-config.yaml"
+                                       :mocks "opts-mocks.yaml"}}
+                               {:config "env-config.yaml"
+                                :mocks "env-mocks.yaml"}
+                               "dev")
+
+      {:current-version "dev"
+       :config "env-config.yaml"
+       :mocks "env-mocks.yaml"
+       :version true
+       :help true}
+      (adapters/inputs->config {:args [{:version true
+                                        :help true}]}
+                               {:config "env-config.yaml"
+                                :mocks "env-mocks.yaml"}
+                               "dev"))))


### PR DESCRIPTION
Adds the following arguments to CLI:
```bash
Moclojer (0.1), simple and efficient HTTP mock server.
  -c, --config  <file> moclojer.yml Config path <file> or the CONFIG environment variable.
  -m, --mocks   <file>              OpenAPI v3 mocks path <file> or the MOCKS environment variable.
  -v, --version                     Show version.
  -h, --help                        Show this Help.
```
Works on `clj -M:run`, `java -jar moclojer.jar` and `moclojer_bin`.

Closes #62 