### PR TITLE
fix: make watcher work again

### DIFF
--- a/docs/releases/next.md
+++ b/docs/releases/next.md
@@ -6,6 +6,8 @@
 ## What's Changed
 
 * Reduce maintenance complexity caused by the OpenAPI specification by @avelino and @rodweb <https://github.com/moclojer/moclojer/issues/113>
+* Fixed configuration file observer, it was not working by
+@rodweb <https://github.com/moclojer/moclojer/issues/120>
 
 ## Contributors
 

--- a/src/moclojer/core.clj
+++ b/src/moclojer/core.clj
@@ -52,14 +52,15 @@
   (let [generate-routes (fn [config-path mocks-path]
                           (router/smart-router {::router/config (open-file config-path)
                                                 ::router/mocks  (open-file mocks-path)}))
-        *router (atom (generate-routes config-path mocks-path))]
+        *router (atom (generate-routes config-path mocks-path))
+        get-routes (fn [] @*router)]
     (start-watcher
      [config-path mocks-path]
      (fn [changed]
        (log/info :changed changed)
        (reset! *router (generate-routes config-path mocks-path))))
     (-> {:env                     :prod
-         ::http/routes            @*router
+         ::http/routes            get-routes
          ::http/type              :jetty
          ::http/join?             true
          ::http/container-options {:h2c?                 true


### PR DESCRIPTION
fixed: #120
closed: #125

> was giving too much conflict in the **rebase**, I made it based on the starting point of the `main` branch