### PR TITLE
Adds header to allow any request

### DIFF
--- a/src/moclojer/core.clj
+++ b/src/moclojer/core.clj
@@ -63,6 +63,7 @@
          ::http/routes            get-routes
          ::http/type              :jetty
          ::http/join?             true
+         ::http/allowed-origins   {:creds true :allowed-origins (constantly true)}
          ::http/container-options {:h2c?                 true
                                    :context-configurator context-configurator}
          ::http/host              (or (System/getenv "HOST") "0.0.0.0")

--- a/src/moclojer/core.clj
+++ b/src/moclojer/core.clj
@@ -63,9 +63,9 @@
          ::http/routes            get-routes
          ::http/type              :jetty
          ::http/join?             true
-         ::http/allowed-origins   {:creds true :allowed-origins (constantly true)}
          ;; pedestal default behavior is to return 403 for invalid origins and
          ;; return Access-Control-Allow-Origin as nil
+         ::http/allowed-origins   {:creds true :allowed-origins (constantly true)}
          ::http/container-options {:h2c?                 true
                                    :context-configurator context-configurator}
          ::http/host              (or (System/getenv "HOST") "0.0.0.0")

--- a/src/moclojer/core.clj
+++ b/src/moclojer/core.clj
@@ -64,6 +64,8 @@
          ::http/type              :jetty
          ::http/join?             true
          ::http/allowed-origins   {:creds true :allowed-origins (constantly true)}
+         ;; pedestal default behavior is to return 403 for invalid origins and
+         ;; return Access-Control-Allow-Origin as nil
          ::http/container-options {:h2c?                 true
                                    :context-configurator context-configurator}
          ::http/host              (or (System/getenv "HOST") "0.0.0.0")

--- a/test/moclojer/core_test.clj
+++ b/test/moclojer/core_test.clj
@@ -20,6 +20,19 @@
                :body
                (json/parse-string true))))))
 
+(deftest hello-world-different-origin
+  (let [service-fn (-> {::http/routes (router/smart-router
+                                       {::router/config (yaml/from-file "test/moclojer/resources/moclojer.yml")})}
+                       http/default-interceptors
+                       http/dev-interceptors
+                       http/create-servlet
+                       ::http/service-fn)]
+    (is (= {:hello "Hello, World!"}
+           (-> service-fn
+               (response-for :get "/hello-world" :headers {"Origin" "http://google.com/"})
+               :body
+               (json/parse-string true))))))
+
 (deftest dyanamic-endpoint
   (let [service-fn (-> {::http/routes (router/smart-router
                                        {::router/config (yaml/from-file "test/moclojer/resources/moclojer.yml")})}

--- a/test/moclojer/core_test.clj
+++ b/test/moclojer/core_test.clj
@@ -31,7 +31,14 @@
            (-> service-fn
                (response-for :get "/hello-world" :headers {"Origin" "http://google.com/"})
                :body
-               (json/parse-string true))))))
+               (json/parse-string true))))
+    (is (= nil
+           (get-in
+            (-> service-fn
+                (response-for :get "/hello-world")
+                :body
+                (json/parse-string true))
+            [:headers "Access-Control-Allow-Origin"])))))
 
 (deftest dyanamic-endpoint
   (let [service-fn (-> {::http/routes (router/smart-router


### PR DESCRIPTION
allowing CORS from all other origins.

In the future, we may add a new specification to allow users to define which origins are allowed to target the Moclojer host.

fixed: #123