### PR TITLE
leave core package clean (low cognitive load)

### DIFF
--- a/docs/releases/next.md
+++ b/docs/releases/next.md
@@ -8,6 +8,7 @@
 * Reduce maintenance complexity caused by the OpenAPI specification by @avelino and @rodweb <https://github.com/moclojer/moclojer/issues/113>
 * Fixed configuration file observer, it was not working by @rodweb <https://github.com/moclojer/moclojer/issues/120>
 * Cross-Origin Resource Sharing (CORS) does not work by @vmesel <https://github.com/moclojer/moclojer/issues/123>
+* Leave core package clean (low cognitive load) by @avelino <https://github.com/moclojer/moclojer/pull/134>
 
 ## Contributors
 

--- a/src/moclojer/config.clj
+++ b/src/moclojer/config.clj
@@ -1,7 +1,23 @@
-(ns moclojer.config)
+(ns moclojer.config
+  (:require [babashka.cli :as cli]
+            [clojure.java.io :as io])
+  (:import (java.util Properties)))
+
+(def *pom-info
+  "pom file info load"
+  (delay
+    (let [p (Properties.)]
+      (some-> "META-INF/maven/moclojer/moclojer/pom.properties"
+              io/resource
+              io/reader
+              (->> (.load p)))
+      p)))
+
+(def version
+  "get version from pom properties"
+  (or (get @*pom-info "version") "dev"))
 
 ;; https://specifications.freedesktop.org/basedir-spec/latest/ar01s03.html
-
 (def get-home (System/getProperty "user.home"))
 
 (def get-xdg-config-home
@@ -12,3 +28,22 @@
 (defn with-xdg
   "Will prefix with the XDG home."
   [s] (str get-xdg-config-home "/" s))
+
+(def spec
+  "Configuration Parameters"
+  {:config {:ref     "<file>"
+            :desc    "Config path <file> or the CONFIG enviroment variable."
+            :alias   :c
+            :default "moclojer.yml"}
+   :mocks  {:ref     "<file>"
+            :desc    "OpenAPI v3 mocks path <file> or the MOCKS enviroment variable."
+            :alias   :m}
+   :version {:desc   "Show version."
+             :alias  :v}
+   :help    {:desc   "Show this Help."
+             :alias  :h}})
+
+(def empty-args
+  "Args are empty"
+  (str "moclojer (" version "), simple and efficient HTTP mock server.\r\n"
+       (cli/format-opts {:spec spec :order [:config :mocks :version :help]})))

--- a/src/moclojer/core.clj
+++ b/src/moclojer/core.clj
@@ -1,111 +1,27 @@
 (ns moclojer.core
   (:gen-class)
   (:require [babashka.cli :as cli]
-            [clojure.java.io :as io]
-            [io.pedestal.http :as http]
-            [io.pedestal.http.body-params :as body-params]
-            [io.pedestal.http.jetty]
             [io.pedestal.log :as log]
             [moclojer.adapters :as adapters]
             [moclojer.config :as config]
-            [moclojer.io-utils :refer [open-file]]
-            [moclojer.router :as router]
-            [moclojer.watcher :refer [start-watcher]])
-  (:import (java.util Properties)
-           (org.eclipse.jetty.server.handler.gzip GzipHandler)
-           (org.eclipse.jetty.servlet ServletContextHandler)))
-
-(defn context-configurator
-  "http container options, active gzip"
-  [^ServletContextHandler context]
-  (let [gzip-handler (GzipHandler.)]
-    (.addIncludedMethods gzip-handler (make-array String 0))
-    (.setExcludedAgentPatterns gzip-handler (make-array String 0))
-    (.setGzipHandler context gzip-handler))
-  context)
-
-(def *pom-info
-  "pom file info load"
-  (delay
-    (let [p (Properties.)]
-      (some-> "META-INF/maven/moclojer/moclojer/pom.properties"
-              io/resource
-              io/reader
-              (->> (.load p)))
-      p)))
-
-(defn get-interceptors [service-map]
-  (-> service-map
-      http/default-interceptors
-      (update ::http/interceptors into [http/json-body
-                                        (body-params/body-params)])))
-
-(defn start
-  "start moclojer server"
-  [{:keys [current-version config-path mocks-path]}]
-  (log/info
-   "-> moclojer"
-   :start-server
-   :version current-version
-   :config-path config-path
-   :mocks-path mocks-path)
-  (let [generate-routes (fn [config-path mocks-path]
-                          (router/smart-router {::router/config (open-file config-path)
-                                                ::router/mocks  (open-file mocks-path)}))
-        *router (atom (generate-routes config-path mocks-path))
-        get-routes (fn [] @*router)]
-    (start-watcher
-     [config-path mocks-path]
-     (fn [changed]
-       (log/info :changed changed)
-       (reset! *router (generate-routes config-path mocks-path))))
-    (-> {:env                     :prod
-         ::http/routes            get-routes
-         ::http/type              :jetty
-         ::http/join?             true
-         ;; pedestal default behavior is to return 403 for invalid origins and
-         ;; return Access-Control-Allow-Origin as nil
-         ::http/allowed-origins   {:creds true :allowed-origins (constantly true)}
-         ::http/container-options {:h2c?                 true
-                                   :context-configurator context-configurator}
-         ::http/host              (or (System/getenv "HOST") "0.0.0.0")
-         ::http/port              (or (some-> (System/getenv "PORT")
-                                              Integer/parseInt)
-                                      8000)}
-        get-interceptors
-        http/create-server
-        http/start)))
-
-(def spec {:config {:ref     "<file>"
-                    :desc    "Config path <file> or the CONFIG enviroment variable."
-                    :alias   :c
-                    :default "moclojer.yml"}
-           :mocks  {:ref     "<file>"
-                    :desc    "OpenAPI v3 mocks path <file> or the MOCKS enviroment variable."
-                    :alias   :m}
-           :version {:desc   "Show version."
-                     :alias  :v}
-           :help    {:desc   "Show this Help."
-                     :alias  :h}})
+            [moclojer.server :as server]))
 
 (defn -main
+  "software entry point"
   {:org.babashka/cli {:collect {:args []}}}
   [& args]
-  (let [args-opts (cli/parse-args args {:spec spec})
+  (let [args-opts (cli/parse-args args {:spec config/spec})
         envs {:config (or (System/getenv "CONFIG")
                           (config/with-xdg "moclojer.yml"))
               :mocks (System/getenv "MOCKS")}
-        current-version (or (get @*pom-info "version") "dev")
-        config (adapters/inputs->config args-opts envs current-version)]
+        config (adapters/inputs->config args-opts envs config/version)]
 
     (when (:version config)
-      (println "moclojer" current-version)
+      (log/error "moclojer" config/version)
       (System/exit 0))
 
     (when (:help config)
-      (println
-       (str "moclojer (" current-version "), simple and efficient HTTP mock server.\r\n"
-            (cli/format-opts {:spec spec :order [:config :mocks :version :help]})))
+      (log/error :empty-args config/empty-args)
       (System/exit 0))
 
-    (start config)))
+    (server/start config)))

--- a/src/moclojer/server.clj
+++ b/src/moclojer/server.clj
@@ -1,0 +1,68 @@
+(ns moclojer.server
+  (:require [io.pedestal.http :as http]
+            [io.pedestal.http.body-params :as body-params]
+            [io.pedestal.http.jetty]
+            [io.pedestal.log :as log]
+            [moclojer.server :as server]
+            [moclojer.io-utils :refer [open-file]]
+            [moclojer.router :as router]
+            [moclojer.watcher :refer [start-watcher]])
+  (:import (org.eclipse.jetty.server.handler.gzip GzipHandler)
+           (org.eclipse.jetty.servlet ServletContextHandler)))
+
+(defn context-configurator
+  "http container options, active gzip"
+  [^ServletContextHandler context]
+  (let [gzip-handler (GzipHandler.)]
+    (.addIncludedMethods gzip-handler (make-array String 0))
+    (.setExcludedAgentPatterns gzip-handler (make-array String 0))
+    (.setGzipHandler context gzip-handler))
+  context)
+
+(defn get-interceptors [service-map]
+  (-> service-map
+      http/default-interceptors
+      (update ::http/interceptors into [http/json-body
+                                        (body-params/body-params)])))
+
+(defn start
+  "start moclojer server"
+  [{:keys [current-version config-path mocks-path]}]
+
+  (let [generate-routes (fn [config-path mocks-path]
+                          (router/smart-router {::router/config (open-file config-path)
+                                                ::router/mocks  (open-file mocks-path)}))
+        http-host (or (System/getenv "HOST") "0.0.0.0")
+        http-port (or (some-> (System/getenv "PORT")
+                              Integer/parseInt)
+                      8000)
+        *router (atom (generate-routes config-path mocks-path))
+        get-routes (fn [] @*router)]
+    (log/info
+     "-> moclojer"
+     :start-server
+     :host http-host
+     :port http-port
+     :url (str "http://" http-host ":" http-port)
+     :version current-version
+     :config-path config-path
+     :mocks-path mocks-path)
+    (start-watcher
+     [config-path mocks-path]
+     (fn [changed]
+       (log/info :changed changed)
+       (reset! *router (generate-routes config-path mocks-path))))
+    (-> {:env                     :prod
+         ::http/routes            get-routes
+         ::http/type              :jetty
+         ::http/join?             true
+         ;; pedestal default behavior is to return 403 for invalid origins and
+         ;; return Access-Control-Allow-Origin as nil
+         ::http/allowed-origins   {:creds true :allowed-origins (constantly true)}
+         ::http/container-options {:h2c?                 true
+                                   :context-configurator context-configurator}
+         ::http/host              http-host
+         ::http/port              http-port}
+        get-interceptors
+        http/create-server
+        http/start)))

--- a/src/moclojer/server.clj
+++ b/src/moclojer/server.clj
@@ -3,7 +3,6 @@
             [io.pedestal.http.body-params :as body-params]
             [io.pedestal.http.jetty]
             [io.pedestal.log :as log]
-            [moclojer.server :as server]
             [moclojer.io-utils :refer [open-file]]
             [moclojer.router :as router]
             [moclojer.watcher :refer [start-watcher]])

--- a/test/moclojer/server_test.clj
+++ b/test/moclojer/server_test.clj
@@ -1,10 +1,10 @@
-(ns moclojer.core-test
+(ns moclojer.server-test
   (:require [cheshire.core :as json]
             [clojure.test :refer [deftest is]]
             [io.pedestal.http :as http]
             [io.pedestal.test :refer [response-for]]
             [moclojer.router :as router]
-            [moclojer.core :as core]
+            [moclojer.server :as server]
             [yaml.core :as yaml]))
 
 (deftest hello-world
@@ -69,7 +69,7 @@
 (deftest first-post-route
   (let [service-fn (-> {::http/routes (router/smart-router
                                        {::router/config (yaml/from-file "test/moclojer/resources/moclojer.yml")})}
-                       core/get-interceptors
+                       server/get-interceptors
                        http/dev-interceptors
                        http/create-servlet
                        ::http/service-fn)]


### PR DESCRIPTION
Simplify the startup package by calling internal packages with extremely defined responsibilities

> this is related #133, but does not solve