### PR TITLE
structure to receive vector with configuration not "only" file in FS

### DIFF
--- a/src/moclojer/adapters.clj
+++ b/src/moclojer/adapters.clj
@@ -1,10 +1,17 @@
-(ns moclojer.adapters)
+(ns moclojer.adapters
+  (:require [moclojer.io-utils :refer [open-file]]
+            [moclojer.router :as router]))
 
 (defn inputs->config
-  [{:keys [args opts]} envs current-version]
+  [{:keys [args opts]} envs]
   (let [{:keys [c config m mocks v version h help]} (first args)]
-    {:current-version current-version
-     :config-path (or c config (:config envs) (:config opts))
+    {:config-path (or c config (:config envs) (:config opts))
      :mocks-path (or m mocks (:mocks envs) (:mocks opts))
      :version (or v version (:version opts))
      :help (or h help (:help opts))}))
+
+(defn generate-routes
+  "generate routes from config and mocks (not required)"
+  [config & {:keys [mocks-path] :or {mocks-path nil}}]
+  (atom (router/smart-router {::router/config config
+                              ::router/mocks  (open-file mocks-path)})))

--- a/src/moclojer/core.clj
+++ b/src/moclojer/core.clj
@@ -6,7 +6,6 @@
             [moclojer.log :as log]
             [moclojer.server :as server]))
 
-
 (defn -main
   "software entry point"
   {:org.babashka/cli {:collect {:args []}}}
@@ -16,7 +15,7 @@
         envs {:config (or (System/getenv "CONFIG")
                           (config/with-xdg "moclojer.yml"))
               :mocks (System/getenv "MOCKS")}
-        config (adapters/inputs->config args-opts envs config/version)]
+        config (adapters/inputs->config args-opts envs)]
 
     (when (:version config)
       (log/log :error :version-not-found "moclojer" config/version)
@@ -26,4 +25,4 @@
       (log/log :error :empty-args :empty-config config/empty-args)
       (System/exit 0))
 
-    (server/start config)))
+    (server/start-server-with-file-watcher! config)))

--- a/test/moclojer/adapters_test.clj
+++ b/test/moclojer/adapters_test.clj
@@ -6,8 +6,7 @@
   (testing "inputs->config can read data from all data sources"
     (are [result inputs] (= result inputs)
 
-      {:current-version "dev"
-       :config-path "config.yaml"
+      {:config-path "config.yaml"
        :mocks-path "mocks.yaml"
        :version true
        :help true}
@@ -18,11 +17,9 @@
                                 :opts {:config "opts-config.yaml"
                                        :mocks "opts-mocks.yaml"}}
                                {:config "default-config.yaml"
-                                :mocks "default-mocks.yaml"}
-                               "dev")
+                                :mocks "default-mocks.yaml"})
 
-      {:current-version "dev"
-       :config-path "opts-config.yaml"
+      {:config-path "opts-config.yaml"
        :mocks-path "opts-mocks.yaml"
        :version true
        :help true}
@@ -31,11 +28,9 @@
                                        :mocks "opts-mocks.yaml"
                                        :version true
                                        :help true}}
-                               {}
-                               "dev")
+                               {})
 
-      {:current-version "dev"
-       :config-path "env-config.yaml"
+      {:config-path "env-config.yaml"
        :mocks-path "env-mocks.yaml"
        :version true
        :help true}
@@ -44,16 +39,13 @@
                                 :opts {:config "opts-config.yaml"
                                        :mocks "opts-mocks.yaml"}}
                                {:config "env-config.yaml"
-                                :mocks "env-mocks.yaml"}
-                               "dev")
+                                :mocks "env-mocks.yaml"})
 
-      {:current-version "dev"
-       :config-path "env-config.yaml"
+      {:config-path "env-config.yaml"
        :mocks-path "env-mocks.yaml"
        :version true
        :help true}
       (adapters/inputs->config {:args [{:version true
                                         :help true}]}
                                {:config "env-config.yaml"
-                                :mocks "env-mocks.yaml"}
-                               "dev"))))
+                                :mocks "env-mocks.yaml"}))))

--- a/test/moclojer/framework_test.clj
+++ b/test/moclojer/framework_test.clj
@@ -1,0 +1,23 @@
+(ns moclojer.framework-test
+  (:require [cheshire.core :as json]
+            [clojure.test :refer [deftest is]]
+            [io.pedestal.test :refer [response-for]]
+            [moclojer.adapters :as adapters]
+            [moclojer.server :as server]))
+
+(def *router
+  "create a router from a config map"
+  (adapters/generate-routes
+   [{:endpoint
+     {:method "GET"
+      :path "/example"
+      :response {:status 200
+                 :headers {:Content-Type "application/json"}
+                 :body {:id 123}}}}]))
+
+(deftest framework-test
+  (is (= {:id 123}
+         (-> (server/start-server! *router :start? false)
+             (response-for :get "/example")
+             :body
+             (json/parse-string true)))))


### PR DESCRIPTION
fixed: #188

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new function to generate routes based on configuration and mock data.
  - Enhanced the main application to streamline configuration input.

- **Refactor**
  - Updated namespace declarations to include additional required namespaces.
  - Renamed and modified the server start function for improved clarity and functionality.

- **Bug Fixes**
  - Adjusted the `inputs->config` function to correct the input data structure.

- **Tests**
  - Added new tests for server response and endpoint functionality.

- **Documentation**
  - Removed unnecessary documentation from the `get-interceptors` function.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->