### PR TITLE
[issue 199] fix error unsupported operation exception

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,7 @@ pom.xml.asc
 !test/com/moclojer/resources/
 !.devcontainer
 moclojer.yaml
-moclojer.yml
+!moclojer.yml
 moclojer.edn
 moclojer.json
 *.org

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:paths   ["src"]
  :deps    {cheshire/cheshire             {:mvn/version "5.11.0"}
            io.forward/yaml               {:mvn/version "1.0.11"}
-           io.pedestal/pedestal.jetty    {:mvn/version "0.5.10"}
+           io.pedestal/pedestal.jetty    {:mvn/version "0.5.11-beta-1"}
            io.pedestal/pedestal.route    {:mvn/version "0.5.10"}
            io.pedestal/pedestal.service  {:mvn/version "0.5.10"}
            org.babashka/cli              {:mvn/version "0.7.53"}
@@ -39,6 +39,10 @@
                                     cljfmt/cljfmt                        {:mvn/version "0.9.2"}}
                        :main-opts ["-m" "cognitect.test-runner"]
                        :exec-fn cognitect.test-runner.api/test}
+
+           ;; clj -M:nrepl
+           :nrepl {:extra-deps {cider/cider-nrepl {:mvn/version "0.30.0"}}
+                   :main-opts ["-m" "nrepl.cmdline" "--middleware" "[cider.nrepl/cider-middleware]"]}
 
            ;; Lint the source
            ;; clj -M:lint

--- a/examples/server/README.md
+++ b/examples/server/README.md
@@ -4,5 +4,7 @@ first you need to start a repl
 ```bash
 clj -M:dev:nrepl
 ```
-then you can eval  the namespace `example.core`
+then you can eval  the namespace `example.core/start!` with a moclojer spec
+or with a route map
+
 

--- a/examples/server/README.md
+++ b/examples/server/README.md
@@ -1,0 +1,8 @@
+# Moclojer as framework example
+
+first you need to start a repl 
+```bash
+clj -M:dev:nrepl
+```
+then you can eval  the namespace `example.core`
+

--- a/examples/server/deps.edn
+++ b/examples/server/deps.edn
@@ -1,0 +1,17 @@
+{:paths   ["src"]
+ :deps    {org.clojure/clojure           {:mvn/version "1.11.1"}
+           org.clojure/core.async        {:mvn/version "1.5.648"}
+           com.moclojer/moclojer         {:local/root "../../"}}
+ :aliases {;; Run project
+           ;; clj -A:dev -m moclojer.core
+           :dev      {:extra-paths ["dev"]
+                      :extra-deps  {io.github.clojure/tools.build {:git/tag    "v0.9.6"
+                                                                   :git/sha    "8e78bcc"
+                                                                   :exclusions [org.slf4j/slf4j-nop]}}}
+
+           :nrepl {:extra-deps {cider/cider-nrepl {:mvn/version "0.30.0"}}
+                   :main-opts ["-m" "nrepl.cmdline" "--middleware" "[cider.nrepl/cider-middleware]"]}
+           ;; Lint the source
+           ;; clj -M:lint
+           :lint      {:replace-deps {clj-kondo/clj-kondo {:mvn/version "2023.10.20"}}
+                       :main-opts    ["-m" "clj-kondo.main" "--lint" "src"]}}}

--- a/examples/server/resources/moclojer.yml
+++ b/examples/server/resources/moclojer.yml
@@ -1,0 +1,11 @@
+- endpoint:
+    method: GET
+    path: /hello/:username
+    response:
+      status: 200
+      headers:
+        Content-Type: application/json
+      body: >
+        {
+          "hello": "{{path-params.username}}!"
+        }

--- a/examples/server/src/example/core.clj
+++ b/examples/server/src/example/core.clj
@@ -13,12 +13,19 @@
                  :headers {:Content-Type "application/json"}
                  :body {:id 123}}}}]))
 
+(defn start!
+  ([]
+   (server/start-server! *router))
+  ([config-path]
+   (server/start-server-with-file-watcher! {:config-path config-path})))
+
 (comment
+
   ;starting 
-  (server/start-server! *router)
+  (start!)
 
   ;starting with a file
-  (server/start-server-with-file-watcher! {:config-path "resources/moclojer.yml"}))
+  (start! "resources/moclojer.yml"))
 
 
 

--- a/examples/server/src/example/core.clj
+++ b/examples/server/src/example/core.clj
@@ -1,0 +1,24 @@
+(ns example.core
+  (:require
+   [com.moclojer.adapters :as adapters]
+   [com.moclojer.server :as server]))
+
+(def *router
+  "create a router from a config map"
+  (adapters/generate-routes
+   [{:endpoint
+     {:method "GET"
+      :path "/example"
+      :response {:status 200
+                 :headers {:Content-Type "application/json"}
+                 :body {:id 123}}}}]))
+
+(comment
+  ;starting 
+  (server/start-server! *router)
+
+  ;starting with a file
+  (server/start-server-with-file-watcher! {:config-path "resources/moclojer.yml"}))
+
+
+


### PR DESCRIPTION
The problem was the jetty version, for some reason when import moclojer as framework it has broken with this error
![image](https://github.com/moclojer/moclojer/assets/6428732/60059ad9-2f08-4ec2-9fd3-83736969691b)
the problem always happens when import has framework.

Looking at the internet I found https://clojurians-log.clojureverse.org/pedestal/2022-12-18  and when I up the version of jetty the problem did happen. 

For some reason, when running` clj -M:run` in the /root it worked but if I open a repl from the /root and try to run did not work.

fixed: #204


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new server example with comprehensive documentation.
	- Introduced the ability to start a REPL with an integrated nREPL server.

- **Enhancements**
	- Updated the `io.pedestal/pedestal.jetty` dependency to a newer beta version for improved performance and stability.
	- Included new development and linting aliases to streamline project setup and maintenance.

- **Documentation**
	- Created a README for the server example to assist users in getting started with Moclojer framework examples.

- **Chores**
	- Updated `.gitignore` to exclude specific configuration files, ensuring a cleaner repository state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->