### PR TITLE
WIP doc/swagger support

### DIFF
--- a/docs/creating-mock-server.md
+++ b/docs/creating-mock-server.md
@@ -58,11 +58,95 @@ Create a file named `moclojer.yml` (we will use yaml because it is a more famili
         }
 ```
 
+## Swagger
+
 Describing all endpoints declared in the configuration file, you can see the following:
 
-| path                   | method | descrition                                                                                                                                                                                                                                    |
-| ---------------------- | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `/hello/:username`     | GET    | Will take a parameter from the url called username and return the username dynamically from the response body.                                                                                                                                |
-| `/hello-world`         | GET    | Static endpoint that returns content that is not dynamic.                                                                                                                                                                                     |
-| `/with-params/:param1` | GET    | It will take a parameter from the url called param1 and the query string called param1, and return both parameters dynamically in the response body. Exemplifying how to consume the two types of parameters in the return from the endpoint. |
-| `/first-post-route`    | POST   | It will take a parameter from the body called project, and return the project name dynamically from the response body.                                                                                                                        |
+### `/hello/:username`
+
+{% swagger method="get" path="/hello/:username" baseUrl="" summary="" %}
+
+{% swagger-description %}
+Will take a parameter from the url called username and return the username dynamically from the response body.
+{% endswagger-description %}
+
+{% swagger-parameter in="path" name="username" type="string" required="true" %}{% endswagger-parameter %}
+
+{% swagger-response status="200: OK" description="" %}
+
+```json
+{
+  "hello": "{{path-params.username}}!"
+}
+```
+
+{% endswagger-response %}
+{% endswagger %}
+
+### `/hello-world`
+
+{% swagger method="get" path="/hello-world" baseUrl="" summary="" %}
+
+{% swagger-description %}
+Static endpoint that returns content that is not dynamic.
+{% endswagger-description %}
+
+{% swagger-response status="200: OK" description="" %}
+
+```json
+{
+  "hello": "Hello, World!"
+}
+```
+
+{% endswagger-response %}
+
+{% endswagger %}
+
+{% swagger method="get" path="/with-params/:param1" baseUrl="" summary="" %}
+{% swagger-description %}
+
+### `/with-params/:param1`
+
+{% swagger method="get" path="/with-params/:param1" baseUrl="" summary="" %}
+
+{% swagger-description %}
+It will take a parameter from the url called param1 and the query string called param1, and return both parameters dynamically in the response body. Exemplifying how to consume the two types of parameters in the return from the endpoint.
+{% endswagger-description %}
+
+{% swagger-parameter in="path" name="param1" type="string" required="true" %}{% endswagger-parameter %}
+
+{% swagger-parameter in="query" name="param1" type="string" required="true" %}{% endswagger-parameter %}
+
+{% swagger-response status="200: OK" description="" %}
+
+```json
+{
+  "path-params": "{{path-params.param1}}",
+  "query-params": "{{query-params.param1}}"
+}
+```
+
+{% endswagger-response %}
+{% endswagger %}
+
+### `/with-params/:param1`
+
+{% swagger method="post" path="first-post-route" baseUrl="" summary="" %}
+
+{% swagger-description %}
+It will take a parameter from the body called project, and return the project name dynamically from the response body.
+{% endswagger-description %}
+
+{% swagger-parameter in="body" name="project" type="string" required="true" %}{% endswagger-parameter %}
+
+{% swagger-response status="200: OK" description="" %}
+
+```json
+{
+  "project": "{{json-params.project}}"
+}
+```
+
+{% endswagger-response %}
+{% endswagger %}

--- a/docs/creating-mock-server.md
+++ b/docs/creating-mock-server.md
@@ -103,9 +103,6 @@ Static endpoint that returns content that is not dynamic.
 
 {% endswagger %}
 
-{% swagger method="get" path="/with-params/:param1" baseUrl="" summary="" %}
-{% swagger-description %}
-
 ### /with-params/:param1
 
 {% swagger method="get" path="/with-params/:param1" baseUrl="" summary="" %}
@@ -130,7 +127,7 @@ It will take a parameter from the url called param1 and the query string called 
 {% endswagger-response %}
 {% endswagger %}
 
-### /with-params/:param1
+### /first-post-route
 
 {% swagger method="post" path="first-post-route" baseUrl="" summary="" %}
 

--- a/docs/creating-mock-server.md
+++ b/docs/creating-mock-server.md
@@ -60,9 +60,9 @@ Create a file named `moclojer.yml` (we will use yaml because it is a more famili
 
 ## Swagger
 
-Describing all endpoints declared in the configuration file, you can see the following:
+Describing all endpoints declared in the configuration file, you can see the following.
 
-### `/hello/:username`
+### /hello/:username
 
 {% swagger method="get" path="/hello/:username" baseUrl="" summary="" %}
 
@@ -83,7 +83,7 @@ Will take a parameter from the url called username and return the username dynam
 {% endswagger-response %}
 {% endswagger %}
 
-### `/hello-world`
+### /hello-world
 
 {% swagger method="get" path="/hello-world" baseUrl="" summary="" %}
 
@@ -106,7 +106,7 @@ Static endpoint that returns content that is not dynamic.
 {% swagger method="get" path="/with-params/:param1" baseUrl="" summary="" %}
 {% swagger-description %}
 
-### `/with-params/:param1`
+### /with-params/:param1
 
 {% swagger method="get" path="/with-params/:param1" baseUrl="" summary="" %}
 
@@ -130,7 +130,7 @@ It will take a parameter from the url called param1 and the query string called 
 {% endswagger-response %}
 {% endswagger %}
 
-### `/with-params/:param1`
+### /with-params/:param1
 
 {% swagger method="post" path="first-post-route" baseUrl="" summary="" %}
 

--- a/docs/creating-mock-server.md
+++ b/docs/creating-mock-server.md
@@ -129,7 +129,7 @@ It will take a parameter from the url called param1 and the query string called 
 
 ### /first-post-route
 
-{% swagger method="post" path="first-post-route" baseUrl="" summary="" %}
+{% swagger method="post" path="/first-post-route" baseUrl="" summary="" %}
 
 {% swagger-description %}
 It will take a parameter from the body called project, and return the project name dynamically from the response body.

--- a/docs/external-body.md
+++ b/docs/external-body.md
@@ -16,7 +16,7 @@ external-body:
 
 **We support two providers _(file type)_:**
 
-* `json`
+* `json`, _with file support (on local disk) or remote via http_
 * `xlsx` **(excel)**
 
 > it is possible to use template rendering to declare the `path` of the file, see more [here](template.md).
@@ -33,8 +33,28 @@ external-body:
         Content-Type: application/json
       external-body:
         provider: json
-        path: test/moclojer/resources/text-plan.json
+        path: test/com/moclojer/resources/text-plan.json
 ```
+
+**Swagger:**
+
+{% swagger method="get" path="/external-body-text" baseUrl="" summary="" %}
+
+{% swagger-description %}
+Will return the text from the file `test/com/moclojer/resources/text-plan.json`.
+{% endswagger-description %}
+
+{% swagger-response status="200: OK" description="" %}
+
+```json
+{
+    "a": 123,
+    "b": "abc"
+}
+```
+
+{% endswagger-response %}
+{% endswagger %}
 
 ## http request (API proxy)
 
@@ -52,6 +72,29 @@ You can use the `json` provider to make URL (site) requests and have it returned
         provider: json
         path: https://pokeapi.co/api/v2/pokemon/phanpy
 ```
+
+**Swagger:**
+
+{% swagger method="get" path="/pokemon/phanpy" baseUrl="" summary="" %}
+
+{% swagger-description %}
+Will return the text from the URL `https://pokeapi.co/api/v2/pokemon/phanpy`.
+{% endswagger-description %}
+
+{% swagger-response status="200: OK" description="" %}
+
+```json
+{"abilities":
+  [{"ability":
+    {
+      "name":"pickup",
+      "url":"https://pokeapi.co/api/v2/ability/53/"
+    }
+  ...
+```
+
+{% endswagger-response %}
+{% endswagger %}
 
 ## `xlsx` Excel type
 
@@ -78,9 +121,22 @@ name | langs
 avelino | clojure, go
 chicao | clojure, python
 
-**response _(expected)_:**
+**Swagger:**
+
+{% swagger method="get" path="/xlsx" baseUrl="" summary="" %}
+
+{% swagger-description %}
+Will return the text from the file `test/com/moclojer/resources/excel-sample.xlsx`.
+{% endswagger-description %}
+
+{% swagger-response status="200: OK" description="" %}
 
 ```json
-[{"name": "avelino", "langs": "clojure, go"},
-{"name": "chicao","langs": "clojure, python"}]
+[
+  {"name": "avelino", "langs": "clojure, go"},
+  {"name": "chicao","langs": "clojure, python"}
+]
 ```
+
+{% endswagger-response %}
+{% endswagger %}

--- a/docs/multi-domain-support.md
+++ b/docs/multi-domain-support.md
@@ -20,3 +20,22 @@ To add a specific domain for the endpoint just put the tag “host” for which 
           "domain": "sub.moclojer.com"
         }
 ```
+
+**Swagger:**
+
+{% swagger method="get" path="/multihost-sub" baseUrl="sub.moclojer.com" summary="" %}
+
+{% swagger-description %}
+Specific domain for the endpoint (aka baseUrl).
+{% endswagger-description %}
+
+{% swagger-response status="200: OK" description="" %}
+
+```json
+{
+  "domain": "sub.moclojer.com"
+}
+```
+
+{% endswagger-response %}
+{% endswagger %}

--- a/docs/webhook-support.md
+++ b/docs/webhook-support.md
@@ -30,3 +30,24 @@ In addition, it will make a request to the `https://moclojer.com/api/webhook` en
 * `sleep-time` _(field is optional, default value of `60 seconds`)_: is used to delay the request to the webhook endpoint, if you want to simulate a long processing time before sending the request.
 
 > Moclojer will not wait for the response from the webhook endpoint; it will only send the request and continue to respond to the original request. This process is asynchronous.
+
+**Swagger:**
+
+{% swagger method="get" path="/with-webhook" baseUrl="" summary="" %}
+
+{% swagger-description %}
+When making a request to the `/with-webhook` endpoint, the moclojer will respond with status `200` and body `{"id": 123}`.
+In addition, it will make a request to the `https://moclojer.com/api/webhook` endpoint with method `POST` and body `{"id": 123, "another-field": "it's working"}`.
+{% endswagger-description %}
+
+{% swagger-response status="200: OK" description="" %}
+
+```json
+{
+  "id": 123,
+  "another-field": "it's working"
+}
+```
+
+{% endswagger-response %}
+{% endswagger %}


### PR DESCRIPTION
fixed: #196

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit



## Summary by CodeRabbit

- **Documentation**
	- Enhanced API documentation with structured Swagger definitions for improved clarity.
		- Included detailed endpoint information for `external-body-text` and `pokemon/phanpy`.
		- Updated `json` provider path in the `external-body` section.
	- Added Swagger documentation for a specific domain endpoint, including the definition of the baseUrl and corresponding response.
	- Introduced Swagger documentation for the `/with-webhook` endpoint, including request, response structure, and asynchronous behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->