### PR TITLE
 Do not generate the jar with uberjar, but with `b/jar` instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,19 +127,19 @@ clj -A:dev -M --report stderr -m com.moclojer.build
 
 We distribute the library via [Clojars](https://clojars.org/com.moclojer/moclojer).
 
-**Clojure CLI/deps.edn**
+### Clojure CLI/deps.edn
 
 ```clojure
 com.moclojer/moclojer {:mvn/version "0.3.0"}
 ```
 
-**Leiningen/Boot**
+### Leiningen/Boot
 
 ```clojure
 [com.moclojer/moclojer "0.3.0"]
 ```
 
-**[`git`](https://clojure.org/guides/deps_and_cli#_using_git_libraries) in `deps.edn`**
+### [`git`](https://clojure.org/guides/deps_and_cli#_using_git_libraries) in `deps.edn`
 
 ```edn
 {:deps
@@ -148,7 +148,7 @@ com.moclojer/moclojer {:mvn/version "0.3.0"}
                          :git/sha "84df7980a56789d1f0b03b9ee06086e4b33f28f1"}}}
 ```
 
-**example of use:**
+### example of use
 
 ```clj
 (ns my-app.core

--- a/README.md
+++ b/README.md
@@ -125,7 +125,21 @@ clj -A:dev -M --report stderr -m com.moclojer.build
 
 ## framework integrations
 
-We are unable to distribute **moclojer** via clojars because it is larger than `20MB`, if you need to use **moclojer** as a framework we recommend installing it via [`git`](https://clojure.org/guides/deps_and_cli#_using_git_libraries) in `deps.edn`:
+We distribute the library via [Clojars](https://clojars.org/com.moclojer/moclojer).
+
+**Clojure CLI/deps.edn**
+
+```clojure
+com.moclojer/moclojer {:mvn/version "0.3.0"}
+```
+
+**Leiningen/Boot**
+
+```clojure
+[com.moclojer/moclojer "0.3.0"]
+```
+
+**[`git`](https://clojure.org/guides/deps_and_cli#_using_git_libraries) in `deps.edn`**
 
 ```edn
 {:deps

--- a/dev/com/moclojer/build.clj
+++ b/dev/com/moclojer/build.clj
@@ -17,6 +17,19 @@
        ~@body
        (str s#))))
 
+(def pom-template
+  [[:description "Simple and efficient HTTP mock server with specification written in `yaml`, `edn` or `OpenAPI`."]
+   [:url "https://moclojer.com"]
+   [:licenses
+    [:license
+     [:name "MIT License"]
+     [:url "https://opensource.org/licenses/MIT"]]]
+   [:scm
+    [:url "https://github.com/moclojer/moclojer"]
+    [:connection "scm:git:https://github.com/moclojer/moclojer.git"]
+    [:developerConnection "scm:git:ssh:git@github.com:moclojer/moclojer.git"]
+    [:tag (str "v" config/version)]]])
+
 (def options
   (let [basis (b/create-basis {:project "deps.edn"})]
     {:class-dir  class-dir
@@ -27,7 +40,9 @@
      :ns-compile '[com.moclojer.core]
      :uber-file  jar-file
      :jar-file   jar-file
+     :target     "target"
      :src-dirs   (:paths basis)
+     :pom-data   pom-template
      :exclude    ["docs/*" "META-INF/*" "test/*" "target/*"]}))
 
 (defn -main

--- a/docs/releases/next.md
+++ b/docs/releases/next.md
@@ -15,6 +15,7 @@
   * Ensured proper handling of not-found HTTP responses, improving user experience by providing clearer error messages and guidance on next steps
 * sentry support, if set `SENTRY_DSN` ([sentry doc](https://docs.sentry.io/platforms/node/guides/azure-functions/configuration/options/#dsn)) envvar send except to <sentry.io> by @avelino <https://github.com/moclojer/moclojer/issues/195>
 * webhook condition support `:if` by @avelino <https://github.com/moclojer/moclojer/issues/235>
+* clojars distribute by @avelino <https://github.com/moclojer/moclojer/issues/234>
 
 ## Contributors
 

--- a/docs/using-moclojer-as-a-framework.md
+++ b/docs/using-moclojer-as-a-framework.md
@@ -18,13 +18,27 @@ The specification is the main feature of moclojer, and it is the one that allows
 
 ## Distribution
 
-We are unable to distribute **moclojer** via clojars because it is larger than `20MB`, if you need to use **moclojer** as a framework we recommend installing it via [`git`](https://clojure.org/guides/deps_and_cli#_using_git_libraries) in `deps.edn`:
+We distribute the library via [Clojars](https://clojars.org/com.moclojer/moclojer).
+
+**Clojure CLI/deps.edn**
+
+```clojure
+com.moclojer/moclojer {:mvn/version "0.3.0"}
+```
+
+**Leiningen/Boot**
+
+```clojure
+[com.moclojer/moclojer "0.3.0"]
+```
+
+**[`git`](https://clojure.org/guides/deps_and_cli#_using_git_libraries) in `deps.edn`**
 
 ```edn
 {:deps
  {com.moclojer/moclojer {:git/url "https://github.com/moclojer/moclojer.git"
                          :git/tag "v0.3.0"
-                         :git/sha "8bdb1b8ddcf76c527fea005dda50534ec08d3ae3"}}}
+                         :git/sha "84df7980a56789d1f0b03b9ee06086e4b33f28f1"}}}
 ```
 
 ## Example

--- a/docs/using-moclojer-as-a-framework.md
+++ b/docs/using-moclojer-as-a-framework.md
@@ -20,19 +20,19 @@ The specification is the main feature of moclojer, and it is the one that allows
 
 We distribute the library via [Clojars](https://clojars.org/com.moclojer/moclojer).
 
-**Clojure CLI/deps.edn**
+### Clojure CLI/deps.edn
 
 ```clojure
 com.moclojer/moclojer {:mvn/version "0.3.0"}
 ```
 
-**Leiningen/Boot**
+### Leiningen/Boot
 
 ```clojure
 [com.moclojer/moclojer "0.3.0"]
 ```
 
-**[`git`](https://clojure.org/guides/deps_and_cli#_using_git_libraries) in `deps.edn`**
+### [`git`](https://clojure.org/guides/deps_and_cli#_using_git_libraries) in `deps.edn`
 
 ```edn
 {:deps

--- a/docs/webhook-support.md
+++ b/docs/webhook-support.md
@@ -30,8 +30,9 @@ In addition, it will make a request to the `https://moclojer.com/api/webhook` en
 
 * `sleep-time` _(field is optional, default value of `60 seconds`)_: is used to delay the request to the webhook endpoint, if you want to simulate a long processing time before sending the request;
 * `if` _(field is optional, default value of `true`)_: is used to define a condition to send the request to the webhook endpoint. If the condition is not met, the request will not be sent. It is possible to read all the request variables (`path-params.`, `query-params.` or `json-params.`), ending up as follows: `if: json-params.field-name = "moclojer"`.
+  * operators: `=`, `>`, `<`, `>=`, `<=`
 
-> Moclojer will not wait for the response from the webhook endpoint; it will only send the request and continue to respond to the original request. This process is asynchronous.
+> moclojer will not wait for the response from the webhook endpoint; it will only send the request and continue to respond to the original request. This process is asynchronous.
 
 **Swagger:**
 


### PR DESCRIPTION
fixed: #234