### PR TITLE
json output format support

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ parameter | description
 --- | ---
 `-c, --config` | Config path or the CONFIG environment variable. \[**default:** `~/.config/moclojer.yml`\]
 `-m, --mocks` | OpenAPI v3 mocks path or the MOCKS environment variable.
+`-f, --format` | Output and logging format. Either `println` or `json`.
 `-h, --help` | Show help information
 `-v, --version` | Show version information
 

--- a/deps.edn
+++ b/deps.edn
@@ -14,7 +14,8 @@
            org.slf4j/slf4j-simple        {:mvn/version "1.7.36"}
            selmer/selmer                 {:mvn/version "1.12.52"}
            com.github.kbosompem/bb-excel {:mvn/version "0.0.9"}
-           clj-http/clj-http             {:mvn/version "3.12.3"}}
+           clj-http/clj-http             {:mvn/version "3.12.3"}
+           viesti/timbre-json-appender {:mvn/version "0.2.13"}}
  :aliases {;; Run project
            ;; clj -M:run
            :run  {:main-opts ["-m" "babashka.cli.exec"]

--- a/deps.edn
+++ b/deps.edn
@@ -15,7 +15,7 @@
            selmer/selmer                 {:mvn/version "1.12.52"}
            com.github.kbosompem/bb-excel {:mvn/version "0.0.9"}
            clj-http/clj-http             {:mvn/version "3.12.3"}
-           viesti/timbre-json-appender {:mvn/version "0.2.13"}}
+           viesti/timbre-json-appender   {:mvn/version "0.2.13"}}
  :aliases {;; Run project
            ;; clj -M:run
            :run  {:main-opts ["-m" "babashka.cli.exec"]

--- a/docs/releases/next.md
+++ b/docs/releases/next.md
@@ -5,7 +5,7 @@
 
 ## What’s Changed
 
-* Added JSON logging format support. PR #246)[https://github.com/moclojer/moclojer/issues/246]
+* Added JSON logging format support. [PR #246](https://github.com/moclojer/moclojer/issues/246)
 - Updated dependencies `@actions/artifact` to v2.1.5 and `@actions/core` to v1.0.1. [PR #562](https://github.com/actions/upload-artifact/pull/562)
 - Added deprecation notice for versions v3/v2/v1 in the README. [PR #561](https://github.com/actions/upload-artifact/pull/561)
 - Minor fix to the migration README. [PR #523](https://github.com/actions/upload-artifact/pull/523)

--- a/docs/releases/next.md
+++ b/docs/releases/next.md
@@ -5,7 +5,7 @@
 
 ## What’s Changed
 
-* Added json format logging support, contributed by @j0suetm <https://github.com/moclojer/moclojer/issues/244>
+* Added JSON format logging support, contributed by @j0suetm <https://github.com/moclojer/moclojer/issues/244>
 
 ## Contributors
 

--- a/docs/releases/next.md
+++ b/docs/releases/next.md
@@ -16,4 +16,3 @@
 * @eggyhead (contributed to dependency updates)
 * @robherley (added deprecation notice)
 * @andrewakim (fixed migration README)
-

--- a/docs/releases/next.md
+++ b/docs/releases/next.md
@@ -5,8 +5,8 @@
 
 ## What’s Changed
 
-*
+* Added json format logging support, contributed by @j0suetm <https://github.com/moclojer/moclojer/issues/244>
 
 ## Contributors
 
-* @
+* @j0suetm

--- a/docs/releases/next.md
+++ b/docs/releases/next.md
@@ -6,13 +6,14 @@
 ## What’s Changed
 
 * Added JSON logging format support. [PR #246](https://github.com/moclojer/moclojer/issues/246)
-- Updated dependencies `@actions/artifact` to v2.1.5 and `@actions/core` to v1.0.1. [PR #562](https://github.com/actions/upload-artifact/pull/562)
-- Added deprecation notice for versions v3/v2/v1 in the README. [PR #561](https://github.com/actions/upload-artifact/pull/561)
-- Minor fix to the migration README. [PR #523](https://github.com/actions/upload-artifact/pull/523)
+* Updated dependencies `@actions/artifact` to v2.1.5 and `@actions/core` to v1.0.1. [PR #562](https://github.com/actions/upload-artifact/pull/562)
+* Added deprecation notice for versions v3/v2/v1 in the README. [PR #561](https://github.com/actions/upload-artifact/pull/561)
+* Minor fix to the migration README. [PR #523](https://github.com/actions/upload-artifact/pull/523)
 
 ## Contributors
 
-- @j0suetm (added json logging format support)
-- @eggyhead (contributed to dependency updates)
-- @robherley (added deprecation notice)
-- @andrewakim (fixed migration README)
+* @j0suetm (added json logging format support)
+* @eggyhead (contributed to dependency updates)
+* @robherley (added deprecation notice)
+* @andrewakim (fixed migration README)
+

--- a/src/com/moclojer/adapters.clj
+++ b/src/com/moclojer/adapters.clj
@@ -8,7 +8,8 @@
     {:config-path (or c config (:config envs) (:config opts))
      :mocks-path (or m mocks (:mocks envs) (:mocks opts))
      :version (or v version (:version opts))
-     :help (or h help (:help opts))}))
+     :help (or h help (:help opts))
+     :format (:format opts)}))
 
 (defn generate-routes
   "generate routes from config and mocks (not required)"

--- a/src/com/moclojer/adapters.clj
+++ b/src/com/moclojer/adapters.clj
@@ -4,12 +4,12 @@
 
 (defn inputs->config
   [{:keys [args opts]} envs]
-  (let [{:keys [c config m mocks v version h help f format]} (first args)]
+  (let [{:keys [c config m mocks v version h help l log-format]} (first args)]
     {:config-path (or c config (:config envs) (:config opts))
      :mocks-path (or m mocks (:mocks envs) (:mocks opts))
      :version (or v version (:version opts))
      :help (or h help (:help opts))
-     :format (or f format (:format opts))}))
+     :log-format (keyword (or l log-format (:log-format opts)))}))
 
 (defn generate-routes
   "generate routes from config and mocks (not required)"

--- a/src/com/moclojer/adapters.clj
+++ b/src/com/moclojer/adapters.clj
@@ -4,12 +4,12 @@
 
 (defn inputs->config
   [{:keys [args opts]} envs]
-  (let [{:keys [c config m mocks v version h help]} (first args)]
+  (let [{:keys [c config m mocks v version h help f format]} (first args)]
     {:config-path (or c config (:config envs) (:config opts))
      :mocks-path (or m mocks (:mocks envs) (:mocks opts))
      :version (or v version (:version opts))
      :help (or h help (:help opts))
-     :format (:format opts)}))
+     :format (or f format (:format opts))}))
 
 (defn generate-routes
   "generate routes from config and mocks (not required)"

--- a/src/com/moclojer/config.clj
+++ b/src/com/moclojer/config.clj
@@ -31,7 +31,7 @@
    :log-format {:ref     "<log-format>"
                 :desc    "Log output format."
                 :alias   :l
-                :default "println"}
+                :default "default"}
    :help    {:desc   "Show this Help."
              :alias  :h}})
 

--- a/src/com/moclojer/config.clj
+++ b/src/com/moclojer/config.clj
@@ -28,10 +28,10 @@
             :alias   :m}
    :version {:desc   "Show version."
              :alias  :v}
-   :format {:ref     "<format>"
-            :desc    "Output format."
-            :alias   :f
-            :default "println"}
+   :log-format {:ref     "<log-format>"
+                :desc    "Log output format."
+                :alias   :l
+                :default "println"}
    :help    {:desc   "Show this Help."
              :alias  :h}})
 

--- a/src/com/moclojer/config.clj
+++ b/src/com/moclojer/config.clj
@@ -28,6 +28,10 @@
             :alias   :m}
    :version {:desc   "Show version."
              :alias  :v}
+   :format {:ref     "<format>"
+            :desc    "Output format."
+            :alias   :f
+            :default "println"}
    :help    {:desc   "Show this Help."
              :alias  :h}})
 

--- a/src/com/moclojer/core.clj
+++ b/src/com/moclojer/core.clj
@@ -16,7 +16,7 @@
               :mocks (System/getenv "MOCKS")}
         config (adapters/inputs->config args-opts envs)]
 
-    (log/setup :info :auto (:format config))
+    (log/setup (:format config) :info :auto)
 
     (when (:version config)
       (log/log :error :version-not-found "moclojer" config/version)

--- a/src/com/moclojer/core.clj
+++ b/src/com/moclojer/core.clj
@@ -10,12 +10,13 @@
   "software entry point"
   {:org.babashka/cli {:collect {:args []}}}
   [& args]
-  (log/setup :info :auto)
   (let [args-opts (cli/parse-args args {:spec config/spec})
         envs {:config (or (System/getenv "CONFIG")
                           (config/with-xdg "moclojer.yml"))
               :mocks (System/getenv "MOCKS")}
         config (adapters/inputs->config args-opts envs)]
+
+    (log/setup :info :auto (:format config))
 
     (when (:version config)
       (log/log :error :version-not-found "moclojer" config/version)

--- a/src/com/moclojer/core.clj
+++ b/src/com/moclojer/core.clj
@@ -16,7 +16,7 @@
               :mocks (System/getenv "MOCKS")}
         config (adapters/inputs->config args-opts envs)]
 
-    (log/setup (:format config) :info :auto)
+    (log/setup (:log-format config) :info :auto)
 
     (when (:version config)
       (log/log :error :version-not-found "moclojer" config/version)

--- a/src/com/moclojer/core.clj
+++ b/src/com/moclojer/core.clj
@@ -16,7 +16,7 @@
               :mocks (System/getenv "MOCKS")}
         config (adapters/inputs->config args-opts envs)]
 
-    (log/setup (:log-format config) :info :auto)
+    (log/setup :info (:log-format config))
 
     (when (:version config)
       (log/log :error :version-not-found "moclojer" config/version)

--- a/src/com/moclojer/log.clj
+++ b/src/com/moclojer/log.clj
@@ -35,9 +35,9 @@
   {:println core-appenders/println-appender
    :json tas/json-appender})
 
-(defn format->appender
+(defn log-format->appender
   [fmt args]
-  (let [fmt-key (or (keyword fmt) :println)
+  (let [fmt-key (or fmt :println)
         appender-fn (get supported-appenders-fns fmt-key)]
     {fmt-key (apply appender-fn args)}))
 
@@ -47,7 +47,7 @@
   (global-setup (.getParent (Logger/getGlobal))) ;; disable `org.eclipse.jetty` logs
   (let [config {:min-level level
                 :ns-filter {:allow #{"com.moclojer.*"}}
-                :appenders (format->appender fmt args)}
+                :appenders (log-format->appender fmt args)}
         sentry-dsn (or (System/getenv "SENTRY_DSN") nil)]
     (timbre/merge-config! config)
     (when sentry-dsn

--- a/src/com/moclojer/log.clj
+++ b/src/com/moclojer/log.clj
@@ -36,18 +36,18 @@
    :json tas/json-appender})
 
 (defn format->appender
-  [fmt & args]
+  [fmt args]
   (let [fmt-key (or (keyword fmt) :println)
         appender-fn (get supported-appenders-fns fmt-key)]
     {fmt-key (apply appender-fn args)}))
 
 (defn setup
   "timbre setup for logging"
-  [level stream fmt]
+  [level fmt & args]
   (global-setup (.getParent (Logger/getGlobal))) ;; disable `org.eclipse.jetty` logs
   (let [config {:min-level level
                 :ns-filter {:allow #{"com.moclojer.*"}}
-                :appenders (format->appender fmt)}
+                :appenders (format->appender fmt args)}
         sentry-dsn (or (System/getenv "SENTRY_DSN") nil)]
     (timbre/merge-config! config)
     (when sentry-dsn

--- a/src/com/moclojer/log.clj
+++ b/src/com/moclojer/log.clj
@@ -41,9 +41,18 @@
   [fmt]
   (get supported-log-fmts-cfg (or fmt :println)))
 
+(defn clean-timbre-appenders []
+  (->> (reduce-kv
+        (fn [acc k _]
+          (assoc acc k nil))
+        {} (:appenders timbre/*config*))
+       (assoc nil :appenders)
+       timbre/merge-config!))
+
 (defn setup
   "timbre setup for logging"
   [level fmt]
+  (clean-timbre-appenders)
   (global-setup (.getParent (Logger/getGlobal))) ;; disable `org.eclipse.jetty` logs
   (let [config (merge
                  {:min-level level

--- a/test/com/moclojer/adapters_test.clj
+++ b/test/com/moclojer/adapters_test.clj
@@ -9,33 +9,39 @@
       {:config-path "config.yaml"
        :mocks-path "mocks.yaml"
        :version true
-       :help true}
+       :help true
+       :format "println"}
       (adapters/inputs->config {:args [{:config "config.yaml"
                                         :mocks "mocks.yaml"
                                         :version true
                                         :help true}]
                                 :opts {:config "opts-config.yaml"
-                                       :mocks "opts-mocks.yaml"}}
+                                       :mocks "opts-mocks.yaml"
+                                       :format "println"}}
                                {:config "default-config.yaml"
                                 :mocks "default-mocks.yaml"})
 
       {:config-path "opts-config.yaml"
        :mocks-path "opts-mocks.yaml"
        :version true
-       :help true}
+       :help true
+       :format "json"}
       (adapters/inputs->config {:args []
                                 :opts {:config "opts-config.yaml"
                                        :mocks "opts-mocks.yaml"
                                        :version true
-                                       :help true}}
+                                       :help true
+                                       :format "json"}}
                                {})
 
       {:config-path "env-config.yaml"
        :mocks-path "env-mocks.yaml"
        :version true
-       :help true}
+       :help true
+       :format "println"}
       (adapters/inputs->config {:args [{:version true
-                                        :help true}]
+                                        :help true
+                                        :format "println"}]
                                 :opts {:config "opts-config.yaml"
                                        :mocks "opts-mocks.yaml"}}
                                {:config "env-config.yaml"
@@ -44,8 +50,10 @@
       {:config-path "env-config.yaml"
        :mocks-path "env-mocks.yaml"
        :version true
-       :help true}
+       :help true
+       :format "println"}
       (adapters/inputs->config {:args [{:version true
-                                        :help true}]}
+                                        :help true
+                                        :format "println"}]}
                                {:config "env-config.yaml"
                                 :mocks "env-mocks.yaml"}))))

--- a/test/com/moclojer/adapters_test.clj
+++ b/test/com/moclojer/adapters_test.clj
@@ -10,14 +10,14 @@
        :mocks-path "mocks.yaml"
        :version true
        :help true
-       :format "println"}
+       :log-format :println}
       (adapters/inputs->config {:args [{:config "config.yaml"
                                         :mocks "mocks.yaml"
                                         :version true
                                         :help true}]
                                 :opts {:config "opts-config.yaml"
                                        :mocks "opts-mocks.yaml"
-                                       :format "println"}}
+                                       :log-format "println"}}
                                {:config "default-config.yaml"
                                 :mocks "default-mocks.yaml"})
 
@@ -25,23 +25,23 @@
        :mocks-path "opts-mocks.yaml"
        :version true
        :help true
-       :format "json"}
+       :log-format :json}
       (adapters/inputs->config {:args []
                                 :opts {:config "opts-config.yaml"
                                        :mocks "opts-mocks.yaml"
                                        :version true
                                        :help true
-                                       :format "json"}}
+                                       :log-format "json"}}
                                {})
 
       {:config-path "env-config.yaml"
        :mocks-path "env-mocks.yaml"
        :version true
        :help true
-       :format "println"}
+       :log-format :println}
       (adapters/inputs->config {:args [{:version true
                                         :help true
-                                        :format "println"}]
+                                        :log-format "println"}]
                                 :opts {:config "opts-config.yaml"
                                        :mocks "opts-mocks.yaml"}}
                                {:config "env-config.yaml"
@@ -51,9 +51,9 @@
        :mocks-path "env-mocks.yaml"
        :version true
        :help true
-       :format "println"}
+       :log-format :println}
       (adapters/inputs->config {:args [{:version true
                                         :help true
-                                        :format "println"}]}
+                                        :log-format "println"}]}
                                {:config "env-config.yaml"
                                 :mocks "env-mocks.yaml"}))))

--- a/test/com/moclojer/log_test.clj
+++ b/test/com/moclojer/log_test.clj
@@ -8,9 +8,9 @@
     (log/setup :info :json)
     (is (= {:level "info"
             :msg "testing"
-            :hello "moclojer"})
-        (select-keys
-          (-> (log/log :info :testing :hello :moclojer)
-              with-out-str
-              (json/read-str :key-fn keyword))
-          ["msg" "hello" "level"]))))
+            :hello "moclojer"}
+           (select-keys
+             (-> (log/log :info :testing :hello :moclojer)
+                 with-out-str
+                 (json/read-str :key-fn keyword))
+             [:msg :hello :level])))))

--- a/test/com/moclojer/log_test.clj
+++ b/test/com/moclojer/log_test.clj
@@ -1,0 +1,16 @@
+(ns com.moclojer.log-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [com.moclojer.log :as log]
+            [clojure.data.json :as json]))
+
+(deftest json-format-logging-test
+  (testing "stdout content is formatted as json"
+    (log/setup :info :json)
+    (is (= {:level "info"
+            :msg "testing"
+            :hello "moclojer"})
+        (select-keys
+          (-> (log/log :info :testing :hello :moclojer)
+              with-out-str
+              (json/read-str :key-fn keyword))
+          ["msg" "hello" "level"]))))

--- a/test/com/moclojer/log_test.clj
+++ b/test/com/moclojer/log_test.clj
@@ -1,7 +1,8 @@
 (ns com.moclojer.log-test
   (:require [clojure.test :refer [deftest is testing]]
             [com.moclojer.log :as log]
-            [clojure.data.json :as json]))
+            [clojure.data.json :as json]
+            [clojure.string :as str]))
 
 (deftest json-format-logging-test
   (testing "stdout content is formatted as json"
@@ -14,3 +15,14 @@
                  with-out-str
                  (json/read-str :key-fn keyword))
              [:msg :hello :level])))))
+
+(deftest default-format-logging-test
+  (testing "stdout content is formatted as default (println)"
+    (log/setup :info :default)
+    (let [out (-> (log/log :info :testing :hello :moclojer)
+                  with-out-str
+                  (str/split #" "))
+          level (get out 2)
+          msg (str/join " " (take-last 3 out))]
+      [(is (= level "INFO"))
+       (is (= msg ":testing :hello :moclojer\n"))])))


### PR DESCRIPTION
fixed: #244 

Through the api, our logger should now be initialized by calling

```clj
;; (log/setup format, any data needed by that format)
;; for example:

;; println
(log/setup "println" {:stream my-stream})
;; or
(log/setup "json" {:my-json data})
```

When running, this can be setted through the `--format`/`-f` option:

```bash
moclojer ... --format json
```

For now, the supported formats are plain println and json.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Introduced JSON format logging support, enabling users to choose between `println` and `json` output formats.
  - Added a new `-f, --format` command-line option for specifying logging format.
  - Added a new `viesti/timbre-json-appender` dependency to enhance logging capabilities.
  
- **Enhancements**
  - Improved logging setup to dynamically select appenders based on the specified format key.
  
- **Documentation**
  - Updated README and release notes to include details about the new logging features and options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->