### PR TITLE
doc/template: write example read dynamic http header request

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,18 @@
+language: "en-US"
+early_access: false
+reviews:
+  review_status: true
+  profile: "chill"
+  request_changes_workflow: false
+  high_level_summary: true
+  poem: true
+  review_status: true
+  collapse_walkthrough: false
+  auto_review:
+    enabled: true
+    ignore_title_keywords:
+      - "WIP"
+      - "DO NOT MERGE"
+    drafts: false
+chat:
+  auto_reply: true

--- a/docs/releases/next.md
+++ b/docs/releases/next.md
@@ -9,6 +9,7 @@
 * Updated dependencies `@actions/artifact` to v2.1.5 and `@actions/core` to v1.0.1. [PR #562](https://github.com/actions/upload-artifact/pull/562)
 * Added deprecation notice for versions v3/v2/v1 in the README. [PR #561](https://github.com/actions/upload-artifact/pull/561)
 * Minor fix to the migration README. [PR #523](https://github.com/actions/upload-artifact/pull/523)
+* HTTP `header` parameters as variables. [PR #251](https://github.com/moclojer/moclojer/issues/251)
 
 ## Contributors
 
@@ -16,3 +17,4 @@
 * @eggyhead (contributed to dependency updates)
 * @robherley (added deprecation notice)
 * @andrewakim (fixed migration README)
+* @avelino (documentation http `header` parameters)

--- a/docs/template.md
+++ b/docs/template.md
@@ -64,6 +64,7 @@ To access this field in the template, simply use the following syntax: `{{query-
 Parameter passed via **JSON**, generally used in the http verbs `POST`, `PUT` and `DELETE`.
 To access this field in the template, simply use the following syntax: `{{json-params.field-name}}`.
 
+
 **Sample:**
 
 ```yaml
@@ -86,4 +87,33 @@ To access this field in the template, simply use the following syntax: `{{json-p
 curl -X POST http://.../
    -H 'Content-Type: application/json'
    -d '{"field-name":"dynamic field name"}'
+```
+
+## HTTP header request `headers`
+
+All parameters received in the request **header** are passed as template variables, making it possible to use the header data to create logic *(verification)* and/or put it in the return *(in the body)*.
+To access this field in the template, simply use the following syntax: `{{headers.field-name}}`.
+
+**Sample:**
+
+```yaml
+- endpoint:
+    method: POST
+    path: /
+    response:
+      status: 200
+      headers:
+        Content-Type: application/json
+      body: >
+        {
+          "header-params": "{{headers.field-name}}"
+        }
+```
+
+**Sending data:**
+
+```sh
+curl -X POST http://.../
+   -H 'Content-Type: application/json'
+   -H 'Field-Name: dynamic field via header'
 ```


### PR DESCRIPTION
fixed: #251

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Added guidance on using HTTP header data in templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->