### PR TITLE
code style linter, used clojure-lsp

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -6,9 +6,15 @@ jobs:
   linter:
     runs-on: ubuntu-latest
     steps:
-      - uses: DeLaGuardo/setup-clj-kondo@master
-        with:
-          version: '2022.05.31'
       - uses: actions/checkout@v4
-      - name: clj-kondo
-        run: clj-kondo --lint src test
+      - uses: DeLaGuardo/setup-clojure@master
+        with:
+          cli: '1.11.3'
+      - uses: clojure-lsp/setup-clojure-lsp@test-action
+        with:
+          clojure-lsp-version: 2024.04.22-11.50.26
+      - name: clojure-lsp
+        run: |
+          clojure-lsp clean-ns --dry && \
+          clojure-lsp format --dry
+ 

--- a/dev/com/moclojer/build.clj
+++ b/dev/com/moclojer/build.clj
@@ -1,9 +1,10 @@
 (ns com.moclojer.build
   (:refer-clojure :exclude [test])
-  (:require [clojure.string :as string]
-            [clojure.tools.build.api :as b]
-            [com.moclojer.config :as config]
-            [com.moclojer.native-image :as native-image]))
+  (:require
+   [clojure.string :as string]
+   [clojure.tools.build.api :as b]
+   [com.moclojer.config :as config]
+   [com.moclojer.native-image :as native-image]))
 
 (def class-dir "target/classes")
 (def jar-file "target/moclojer.jar")

--- a/dev/com/moclojer/native_image.clj
+++ b/dev/com/moclojer/native_image.clj
@@ -1,8 +1,8 @@
 (ns com.moclojer.native-image
-  (:require [clojure.data.json :as json]
-            [clojure.java.io :as io]
-            [clojure.string :as string]))
-
+  (:require
+   [clojure.data.json :as json]
+   [clojure.java.io :as io]
+   [clojure.string :as string]))
 
 (def initialize-at-build-time
   "list of classes to initialize at build time"

--- a/docs/releases/next.md
+++ b/docs/releases/next.md
@@ -5,13 +5,14 @@
 
 ## What’s Changed
 
-* Added JSON logging format support. [PR #246](https://github.com/moclojer/moclojer/issues/246)
+* Added JSON logging format support. [issue #246](https://github.com/moclojer/moclojer/issues/246)
 * Updated dependencies `@actions/artifact` to v2.1.5 and `@actions/core` to v1.0.1. [PR #562](https://github.com/actions/upload-artifact/pull/562)
 * Added deprecation notice for versions v3/v2/v1 in the README. [PR #561](https://github.com/actions/upload-artifact/pull/561)
 * Minor fix to the migration README. [PR #523](https://github.com/actions/upload-artifact/pull/523)
-* HTTP `header` parameters as variables. [PR #251](https://github.com/moclojer/moclojer/issues/251)
+* HTTP `header` parameters as variables. [issue #251](https://github.com/moclojer/moclojer/issues/251)
 * Added `interceptor-error-handler` function for formatting exceptions as JSON for Internal Server Errors. Integrated error handling into `get-interceptors`. Imported `io.pedestal.interceptor.error` and `clojure.data.json` [PR #254](https://github.com/moclojer/moclojer/pull/254)
-* We should be able to create a dev and prod config map when start moclojer [PR #199](https://github.com/moclojer/moclojer/issues/199)
+* We should be able to create a dev and prod config map when start moclojer [issue #199](https://github.com/moclojer/moclojer/issues/199)
+* code style linter, used clojure-lsp [PR #256](https://github.com/moclojer/moclojer/pull/256)
 
 ## Contributors
 

--- a/src/com/moclojer/adapters.clj
+++ b/src/com/moclojer/adapters.clj
@@ -1,6 +1,7 @@
 (ns com.moclojer.adapters
-  (:require [com.moclojer.io-utils :refer [open-file]]
-            [com.moclojer.router :as router]))
+  (:require
+   [com.moclojer.io-utils :refer [open-file]]
+   [com.moclojer.router :as router]))
 
 (defn inputs->config
   [{:keys [args opts]} envs]

--- a/src/com/moclojer/config.clj
+++ b/src/com/moclojer/config.clj
@@ -1,5 +1,6 @@
 (ns com.moclojer.config
-  (:require [babashka.cli :as cli]))
+  (:require
+   [babashka.cli :as cli]))
 
 (def version
   "get version from pom properties"

--- a/src/com/moclojer/core.clj
+++ b/src/com/moclojer/core.clj
@@ -1,9 +1,10 @@
 (ns com.moclojer.core
-  (:require [babashka.cli :as cli]
-            [com.moclojer.adapters :as adapters]
-            [com.moclojer.config :as config]
-            [com.moclojer.log :as log]
-            [com.moclojer.server :as server])
+  (:require
+   [babashka.cli :as cli]
+   [com.moclojer.adapters :as adapters]
+   [com.moclojer.config :as config]
+   [com.moclojer.log :as log]
+   [com.moclojer.server :as server])
   (:gen-class))
 
 (defn -main

--- a/src/com/moclojer/external_body/core.clj
+++ b/src/com/moclojer/external_body/core.clj
@@ -1,6 +1,7 @@
 (ns com.moclojer.external-body.core
-  (:require [cheshire.core :as cheshire]
-            [com.moclojer.external-body.excel :as xlsx]))
+  (:require
+   [cheshire.core :as cheshire]
+   [com.moclojer.external-body.excel :as xlsx]))
 
 (defn ->str
   "convert body to string, if it is edn it will be converted to json->str"

--- a/src/com/moclojer/external_body/excel.clj
+++ b/src/com/moclojer/external_body/excel.clj
@@ -1,5 +1,6 @@
 (ns com.moclojer.external-body.excel
-  (:require [bb-excel.core :as excel]))
+  (:require
+   [bb-excel.core :as excel]))
 
 (defn ->map
   "converts excel (xlsx and xls) tab/sheet name to map"

--- a/src/com/moclojer/io_utils.clj
+++ b/src/com/moclojer/io_utils.clj
@@ -1,9 +1,11 @@
 (ns com.moclojer.io-utils
-  (:require [clojure.edn :as edn]
-            [clojure.string :as string]
-            [com.moclojer.log :as log]
-            [yaml.core :as yaml])
-  (:import [java.io FileNotFoundException]))
+  (:require
+   [clojure.edn :as edn]
+   [clojure.string :as string]
+   [com.moclojer.log :as log]
+   [yaml.core :as yaml])
+  (:import
+   [java.io FileNotFoundException]))
 
 (defn open-file [path]
   (if (empty? path)

--- a/src/com/moclojer/log.clj
+++ b/src/com/moclojer/log.clj
@@ -1,16 +1,18 @@
 (ns com.moclojer.log
-  (:require [clojure.string :as string]
-            [io.pedestal.interceptor.helpers :as interceptor]
-            [taoensso.timbre :as timbre]
-            [taoensso.timbre.appenders.core :as core-appenders]
-            [taoensso.timbre.appenders.community.sentry :as sentry]
-            [timbre-json-appender.core :as tas])
-  (:import (java.util.logging
-            Filter
-            Formatter
-            Handler
-            LogRecord
-            Logger)))
+  (:require
+   [clojure.string :as string]
+   [io.pedestal.interceptor.helpers :as interceptor]
+   [taoensso.timbre :as timbre]
+   [taoensso.timbre.appenders.community.sentry :as sentry]
+   [taoensso.timbre.appenders.core :as core-appenders]
+   [timbre-json-appender.core :as tas])
+  (:import
+   (java.util.logging
+    Filter
+    Formatter
+    Handler
+    LogRecord
+    Logger)))
 
 (set! *warn-on-reflection* true)
 
@@ -55,9 +57,9 @@
   (clean-timbre-appenders)
   (global-setup (.getParent (Logger/getGlobal))) ;; disable `org.eclipse.jetty` logs
   (let [config (merge
-                 {:min-level level
-                  :ns-filter {:allow #{"com.moclojer.*"}}}
-                 (log-format->mergeable-cfg fmt))
+                {:min-level level
+                 :ns-filter {:allow #{"com.moclojer.*"}}}
+                (log-format->mergeable-cfg fmt))
         sentry-dsn (or (System/getenv "SENTRY_DSN") nil)]
     (timbre/merge-config! config)
     (when sentry-dsn

--- a/src/com/moclojer/router.clj
+++ b/src/com/moclojer/router.clj
@@ -1,8 +1,9 @@
 (ns com.moclojer.router
-  (:require [clojure.data.json :as json]
-            [com.moclojer.log :as log]
-            [com.moclojer.specs.moclojer :as spec]
-            [com.moclojer.specs.openapi :as openapi]))
+  (:require
+   [clojure.data.json :as json]
+   [com.moclojer.log :as log]
+   [com.moclojer.specs.moclojer :as spec]
+   [com.moclojer.specs.openapi :as openapi]))
 
 (def home-endpoint
   "initial/home endpoint URL: /"

--- a/src/com/moclojer/server.clj
+++ b/src/com/moclojer/server.clj
@@ -1,16 +1,18 @@
 (ns com.moclojer.server
-  (:require [clojure.data.json :as json]
-            [com.moclojer.adapters :as adapters]
-            [com.moclojer.config :as config]
-            [com.moclojer.io-utils :refer [open-file]]
-            [com.moclojer.log :as log]
-            [com.moclojer.watcher :refer [start-watch]]
-            [io.pedestal.http :as http]
-            [io.pedestal.http.body-params :as body-params]
-            [io.pedestal.http.jetty]
-            [io.pedestal.interceptor.error :refer [error-dispatch]])
-  (:import (org.eclipse.jetty.server.handler.gzip GzipHandler)
-           (org.eclipse.jetty.servlet ServletContextHandler)))
+  (:require
+   [clojure.data.json :as json]
+   [com.moclojer.adapters :as adapters]
+   [com.moclojer.config :as config]
+   [com.moclojer.io-utils :refer [open-file]]
+   [com.moclojer.log :as log]
+   [com.moclojer.watcher :refer [start-watch]]
+   [io.pedestal.http :as http]
+   [io.pedestal.http.body-params :as body-params]
+   [io.pedestal.http.jetty]
+   [io.pedestal.interceptor.error :refer [error-dispatch]])
+  (:import
+   (org.eclipse.jetty.server.handler.gzip GzipHandler)
+   (org.eclipse.jetty.servlet ServletContextHandler)))
 
 (defn context-configurator
   "http container options, active gzip"

--- a/src/com/moclojer/specs/moclojer.clj
+++ b/src/com/moclojer/specs/moclojer.clj
@@ -1,9 +1,10 @@
 (ns com.moclojer.specs.moclojer
-  (:require [clojure.string :as string]
-            [io.pedestal.http.route :as route]
-            [com.moclojer.external-body.core :as ext-body]
-            [com.moclojer.webhook :as webhook]
-            [selmer.parser :as selmer]))
+  (:require
+   [clojure.string :as string]
+   [com.moclojer.external-body.core :as ext-body]
+   [com.moclojer.webhook :as webhook]
+   [io.pedestal.http.route :as route]
+   [selmer.parser :as selmer]))
 
 (defn render-template
   [template request]

--- a/src/com/moclojer/specs/openapi.clj
+++ b/src/com/moclojer/specs/openapi.clj
@@ -1,5 +1,6 @@
 (ns com.moclojer.specs.openapi
-  (:require [clojure.string :as str]))
+  (:require
+   [clojure.string :as str]))
 
 (defn convert-path
   "converts OpenAPI path to moclojer path

--- a/src/com/moclojer/webhook.clj
+++ b/src/com/moclojer/webhook.clj
@@ -1,7 +1,8 @@
 (ns com.moclojer.webhook
-  (:require [clj-http.client :as client]
-            [clojure.core.async :as a]
-            [com.moclojer.log :as log]))
+  (:require
+   [clj-http.client :as client]
+   [clojure.core.async :as a]
+   [com.moclojer.log :as log]))
 
 (defn request-after-delay
   "after a delay call http-request, return body"

--- a/test/com/moclojer/adapters_test.clj
+++ b/test/com/moclojer/adapters_test.clj
@@ -1,6 +1,7 @@
 (ns com.moclojer.adapters-test
-  (:require [clojure.test :refer [are deftest testing]]
-            [com.moclojer.adapters :as adapters]))
+  (:require
+   [clojure.test :refer [are deftest testing]]
+   [com.moclojer.adapters :as adapters]))
 
 (deftest inputs-config-test
   (testing "inputs->config can read data from all data sources"

--- a/test/com/moclojer/aux/samples.clj
+++ b/test/com/moclojer/aux/samples.clj
@@ -1,8 +1,9 @@
 (ns com.moclojer.aux.samples
-  (:require [io.pedestal.http :as http]
-            [io.pedestal.http.ring-middlewares :as middlewares]
-            [ring.util.mime-type :as mime]
-            [yaml.core :as yaml]))
+  (:require
+   [io.pedestal.http :as http]
+   [io.pedestal.http.ring-middlewares :as middlewares]
+   [ring.util.mime-type :as mime]
+   [yaml.core :as yaml]))
 
 (def yaml-sample
   (yaml/parse-string "
@@ -27,7 +28,6 @@
                              :headers {:content-type "applicantion/json"}
                              :body    {:id 1 :name "chico"}}
                :router-name :get-pet-by-id}}])
-
 
 (defonce *http-state (atom nil))
 

--- a/test/com/moclojer/config_test.clj
+++ b/test/com/moclojer/config_test.clj
@@ -1,6 +1,7 @@
 (ns com.moclojer.config-test
-  (:require [clojure.test :refer [deftest is testing]]
-            [com.moclojer.config :as config]))
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [com.moclojer.config :as config]))
 
 (deftest with-xdg-test
   (testing "It generates an rc name as expected."

--- a/test/com/moclojer/edn_test.clj
+++ b/test/com/moclojer/edn_test.clj
@@ -1,10 +1,10 @@
 (ns com.moclojer.edn-test
-  (:require [cheshire.core :as json]
-            [clojure.edn :as edn]
-            [clojure.test :refer [deftest is testing]]
-            [com.moclojer.helpers-test :as helpers]
-            [io.pedestal.test :refer [response-for]]))
-
+  (:require
+   [cheshire.core :as json]
+   [clojure.edn :as edn]
+   [clojure.test :refer [deftest is testing]]
+   [com.moclojer.helpers-test :as helpers]
+   [io.pedestal.test :refer [response-for]]))
 
 (deftest dynamic-endpoint-edn
   (let [service-fn (helpers/service-fn (edn/read-string (str "[" (slurp "test/com/moclojer/resources/moclojer.edn") "]")))]

--- a/test/com/moclojer/external_body/core_test.clj
+++ b/test/com/moclojer/external_body/core_test.clj
@@ -1,10 +1,11 @@
 (ns com.moclojer.external-body.core-test
-  (:require [clojure.data.json :as jsond]
-            [clojure.test :refer [deftest is testing]]
-            [com.moclojer.external-body.core :as core]
-            [com.moclojer.helpers-test :as helpers]
-            [io.pedestal.test :refer [response-for]]
-            [yaml.core :as yaml]))
+  (:require
+   [clojure.data.json :as jsond]
+   [clojure.test :refer [deftest is testing]]
+   [com.moclojer.external-body.core :as core]
+   [com.moclojer.helpers-test :as helpers]
+   [io.pedestal.test :refer [response-for]]
+   [yaml.core :as yaml]))
 
 (def data-text
   {:provider "json"

--- a/test/com/moclojer/external_body/excel_test.clj
+++ b/test/com/moclojer/external_body/excel_test.clj
@@ -1,9 +1,10 @@
 (ns com.moclojer.external-body.excel-test
-  (:require [cheshire.core :as json]
-            [clojure.test :refer [deftest is]]
-            [com.moclojer.helpers-test :as helpers]
-            [io.pedestal.test :refer [response-for]]
-            [yaml.core :as yaml]))
+  (:require
+   [cheshire.core :as json]
+   [clojure.test :refer [deftest is]]
+   [com.moclojer.helpers-test :as helpers]
+   [io.pedestal.test :refer [response-for]]
+   [yaml.core :as yaml]))
 
 (deftest xlsx-config-test
   (is (= [{:name "avelino", :langs "golang"}

--- a/test/com/moclojer/framework_test.clj
+++ b/test/com/moclojer/framework_test.clj
@@ -1,9 +1,10 @@
 (ns com.moclojer.framework-test
-  (:require [cheshire.core :as json]
-            [clojure.test :refer [deftest is]]
-            [com.moclojer.adapters :as adapters]
-            [com.moclojer.server :as server]
-            [io.pedestal.test :refer [response-for]]))
+  (:require
+   [cheshire.core :as json]
+   [clojure.test :refer [deftest is]]
+   [com.moclojer.adapters :as adapters]
+   [com.moclojer.server :as server]
+   [io.pedestal.test :refer [response-for]]))
 
 (def *router
   "create a router from a config map"

--- a/test/com/moclojer/helpers_test.clj
+++ b/test/com/moclojer/helpers_test.clj
@@ -1,7 +1,8 @@
 (ns com.moclojer.helpers-test
-  (:require [com.moclojer.router :as router]
-            [com.moclojer.server :as server]
-            [io.pedestal.http :as http]))
+  (:require
+   [com.moclojer.router :as router]
+   [com.moclojer.server :as server]
+   [io.pedestal.http :as http]))
 
 (defn service-fn
   "create a service function of pedestal from a config map"

--- a/test/com/moclojer/io_aux.clj
+++ b/test/com/moclojer/io_aux.clj
@@ -1,10 +1,12 @@
 (ns com.moclojer.io-aux
   (:refer-clojure :exclude [load])
-  (:require [clojure.string :as string]
-            [yaml.core :as yaml])
-  (:import (java.io File)
-           (java.nio.file Files)
-           (java.nio.file.attribute FileAttribute)))
+  (:require
+   [clojure.string :as string]
+   [yaml.core :as yaml])
+  (:import
+   (java.io File)
+   (java.nio.file Files)
+   (java.nio.file.attribute FileAttribute)))
 
 (defn write-config
   "write configuration file with receiving data type (yaml or edn) and structure"

--- a/test/com/moclojer/log_test.clj
+++ b/test/com/moclojer/log_test.clj
@@ -1,8 +1,9 @@
 (ns com.moclojer.log-test
-  (:require [clojure.test :refer [deftest is testing]]
-            [com.moclojer.log :as log]
-            [clojure.data.json :as json]
-            [clojure.string :as str]))
+  (:require
+   [clojure.data.json :as json]
+   [clojure.string :as str]
+   [clojure.test :refer [deftest is testing]]
+   [com.moclojer.log :as log]))
 
 (deftest json-format-logging-test
   (testing "stdout content is formatted as json"
@@ -11,10 +12,10 @@
             :msg "testing"
             :hello "moclojer"}
            (select-keys
-             (-> (log/log :info :testing :hello :moclojer)
-                 with-out-str
-                 (json/read-str :key-fn keyword))
-             [:msg :hello :level])))))
+            (-> (log/log :info :testing :hello :moclojer)
+                with-out-str
+                (json/read-str :key-fn keyword))
+            [:msg :hello :level])))))
 
 (deftest default-format-logging-test
   (testing "stdout content is formatted as default (println)"

--- a/test/com/moclojer/router_test.clj
+++ b/test/com/moclojer/router_test.clj
@@ -1,7 +1,8 @@
 (ns com.moclojer.router-test
-  (:require [clojure.test :refer [deftest is testing]]
-            [com.moclojer.aux.samples :as aux.samples]
-            [com.moclojer.router :as router]))
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [com.moclojer.aux.samples :as aux.samples]
+   [com.moclojer.router :as router]))
 
 (deftest smart-router-test
   (testing "should make edn routers"

--- a/test/com/moclojer/server_test.clj
+++ b/test/com/moclojer/server_test.clj
@@ -1,10 +1,11 @@
 (ns com.moclojer.server-test
-  (:require [cheshire.core :as json]
-            [clojure.test :refer [deftest is]]
-            [clojure.string :as string]
-            [com.moclojer.helpers-test :as helpers]
-            [io.pedestal.test :refer [response-for]]
-            [yaml.core :as yaml]))
+  (:require
+   [cheshire.core :as json]
+   [clojure.string :as string]
+   [clojure.test :refer [deftest is]]
+   [com.moclojer.helpers-test :as helpers]
+   [io.pedestal.test :refer [response-for]]
+   [yaml.core :as yaml]))
 
 (deftest hello-world
   (is (= {:hello "Hello, World!"}
@@ -82,12 +83,11 @@
              (response-for :get "/v1/hello")
              :body
              (json/parse-string true))))
-   (is (= {:hello-v1 "hello world!"}
+  (is (= {:hello-v1 "hello world!"}
          (-> (helpers/service-fn (yaml/from-file "test/com/moclojer/resources/moclojer.yml"))
              (response-for :get "/v1/hello/")
              :body
              (json/parse-string true)))))
-
 
 (deftest multi-path-param
   (is (= {:username "moclojer-123"
@@ -103,7 +103,7 @@
              (response-for :get "/helloo/moclojer")
              :status)))
   (is (string/includes?
-        (-> (helpers/service-fn (yaml/from-file "test/com/moclojer/resources/mock-syntax-error.yml"))
-            (response-for :get "/helloo/moclojer")
-            :body)
-        "error")))
+       (-> (helpers/service-fn (yaml/from-file "test/com/moclojer/resources/mock-syntax-error.yml"))
+           (response-for :get "/helloo/moclojer")
+           :body)
+       "error")))

--- a/test/com/moclojer/specs/openapi_test.clj
+++ b/test/com/moclojer/specs/openapi_test.clj
@@ -1,10 +1,11 @@
 (ns com.moclojer.specs.openapi-test
-  (:require [cheshire.core :as json]
-            [clojure.test :refer [deftest is testing]]
-            [com.moclojer.helpers-test :as helpers]
-            [com.moclojer.specs.openapi :as openapi]
-            [io.pedestal.test :refer [response-for]]
-            [yaml.core :as yaml]))
+  (:require
+   [cheshire.core :as json]
+   [clojure.test :refer [deftest is testing]]
+   [com.moclojer.helpers-test :as helpers]
+   [com.moclojer.specs.openapi :as openapi]
+   [io.pedestal.test :refer [response-for]]
+   [yaml.core :as yaml]))
 
 (def petstore
   {:config "META-INF/openapi-spec/v3.0/petstore-expanded.yaml"

--- a/test/com/moclojer/webhook_test.clj
+++ b/test/com/moclojer/webhook_test.clj
@@ -1,10 +1,11 @@
 (ns com.moclojer.webhook-test
-  (:require [cheshire.core :as json]
-            [clojure.test :refer [deftest is]]
-            [com.moclojer.helpers-test :as helpers]
-            [com.moclojer.webhook :as webhook]
-            [io.pedestal.test :refer [response-for]]
-            [yaml.core :as yaml]))
+  (:require
+   [cheshire.core :as json]
+   [clojure.test :refer [deftest is]]
+   [com.moclojer.helpers-test :as helpers]
+   [com.moclojer.webhook :as webhook]
+   [io.pedestal.test :refer [response-for]]
+   [yaml.core :as yaml]))
 
 (def body {:id 123})
 


### PR DESCRIPTION
Switching" from clj-kondo to clojure-lsp _(it uses clj-kondo in the background)_.

With the goal of following the path that large Clojure projects are taking, we are setting up our linter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced linting and formatting setup for Clojure projects using `clojure-lsp`.
- **Refactor**
  - Improved readability of namespace declarations and `:require` sections across multiple files for better maintainability.
- **Style**
  - Adjusted indentation and alignment in various files to adhere to coding standards.
- **Tests**
  - Reformatted test files to enhance clarity and consistency in test declarations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->