### PR TITLE
Load parsed body correctly

### DIFF
--- a/src/com/moclojer/core.clj
+++ b/src/com/moclojer/core.clj
@@ -1,9 +1,10 @@
 (ns com.moclojer.core
-  (:require [babashka.cli :as cli]
-            [com.moclojer.adapters :as adapters]
-            [com.moclojer.config :as config]
-            [com.moclojer.log :as log]
-            [com.moclojer.server :as server])
+  (:require
+   [babashka.cli :as cli]
+   [com.moclojer.adapters :as adapters]
+   [com.moclojer.config :as config]
+   [com.moclojer.log :as log]
+   [com.moclojer.server :as server])
   (:gen-class))
 
 (defn -main

--- a/src/com/moclojer/log.clj
+++ b/src/com/moclojer/log.clj
@@ -55,9 +55,9 @@
   (clean-timbre-appenders)
   (global-setup (.getParent (Logger/getGlobal))) ;; disable `org.eclipse.jetty` logs
   (let [config (merge
-                 {:min-level level
-                  :ns-filter {:allow #{"com.moclojer.*"}}}
-                 (log-format->mergeable-cfg fmt))
+                {:min-level level
+                 :ns-filter {:allow #{"com.moclojer.*"}}}
+                (log-format->mergeable-cfg fmt))
         sentry-dsn (or (System/getenv "SENTRY_DSN") nil)]
     (timbre/merge-config! config)
     (when sentry-dsn

--- a/src/com/moclojer/specs/moclojer.clj
+++ b/src/com/moclojer/specs/moclojer.clj
@@ -1,9 +1,10 @@
 (ns com.moclojer.specs.moclojer
-  (:require [clojure.string :as string]
-            [io.pedestal.http.route :as route]
-            [com.moclojer.external-body.core :as ext-body]
-            [com.moclojer.webhook :as webhook]
-            [selmer.parser :as selmer]))
+  (:require
+   [clojure.string :as string]
+   [com.moclojer.external-body.core :as ext-body]
+   [com.moclojer.webhook :as webhook]
+   [io.pedestal.http.route :as route]
+   [selmer.parser :as selmer]))
 
 (defn render-template
   [template request]

--- a/src/com/moclojer/webhook.clj
+++ b/src/com/moclojer/webhook.clj
@@ -15,7 +15,8 @@
        (log/log :error :webhook-warning
                 :invalid-body body
                 :message (.getMessage e))
-       "{}"))))
+       {:error "failed to read and parse request body"
+        :message (.getMessage e)}))))
 
 (defn request-after-delay
   "after a delay call http-request, return body"
@@ -41,7 +42,7 @@
               (client/request req)
               (log/log :info :sleep sleep-time :webhook-done hashed-req)
               (catch Exception e
-                (log/log :error :webhook-failed hashed-req)
+                (log/log :error :webhook-failed hashed-req :message (.getMessage e))
                 (.printStackTrace e))))))
       (log/log :info :sleep sleep-time :webhook-done hashed-req :condition condition))
 

--- a/src/com/moclojer/webhook.clj
+++ b/src/com/moclojer/webhook.clj
@@ -1,8 +1,8 @@
 (ns com.moclojer.webhook
   (:require
-   [clojure.data.json :as json]
    [clj-http.client :as client]
    [clojure.core.async :as a]
+   [clojure.data.json :as json]
    [clojure.edn :as edn]
    [com.moclojer.log :as log]))
 
@@ -21,7 +21,7 @@
   "after a delay call http-request, return body"
   [request]
   (let [req (-> request
-                (update :condition #(or % true))
+                (update :condition #(if (boolean? %) % true))
                 (update :headers #(or % {"Content-Type" "application/json"}))
                 (update :sleep-time #(or % 60))
                 (update :body #(read-body (or % "{}"))))
@@ -45,4 +45,6 @@
                 (.printStackTrace e))))))
       (log/log :info :sleep sleep-time :webhook-done hashed-req :condition condition))
 
-    body))
+    (if condition
+      (:body request)
+      "{}")))

--- a/src/com/moclojer/webhook.clj
+++ b/src/com/moclojer/webhook.clj
@@ -1,27 +1,48 @@
 (ns com.moclojer.webhook
-  (:require [clj-http.client :as client]
-            [clojure.core.async :as a]
-            [com.moclojer.log :as log]))
+  (:require
+   [clojure.data.json :as json]
+   [clj-http.client :as client]
+   [clojure.core.async :as a]
+   [clojure.edn :as edn]
+   [com.moclojer.log :as log]))
+
+(defn read-body
+  [body]
+  (json/write-str
+   (try
+     (edn/read-string body)
+     (catch Exception e
+       (log/log :error :webhook-warning
+                :invalid-body body
+                :message (.getMessage e))
+       "{}"))))
 
 (defn request-after-delay
   "after a delay call http-request, return body"
-  [{:keys [url method body headers sleep-time condition]
-    :or {headers {}
-         condition true
-         ; in milliseconds, 1 minute is 60000 milliseconds
-         sleep-time 60}}]
-  (let [req {:url url
-             :method method
-             :headers headers
-             :body body}
-        body-out (if condition body "{}")]
-    (log/log :info :sleep sleep-time :webhook-start req)
+  [request]
+  (let [req (-> request
+                (update :condition #(or % true))
+                (update :headers #(or % {"Content-Type" "application/json"}))
+                (update :sleep-time #(or % 60))
+                (update :body #(read-body (or % "{}"))))
+        {:keys [body condition sleep-time]} req
+        hashed-req (-> (assoc req :body-hash (hash body))
+                       (dissoc :body))]
+    (log/log :info
+             :sleep (:sleep-time req)
+             :webhook-start hashed-req)
+
     (if condition
       (a/go
         (a/thread
           (do
             (Thread/sleep (long sleep-time))
-            (client/request req)
-            (log/log :info :sleep sleep-time :webhook-done req))))
-      (log/log :info :sleep sleep-time :webhook-done req :condition condition))
-    body-out))
+            (try
+              (client/request req)
+              (log/log :info :sleep sleep-time :webhook-done hashed-req)
+              (catch Exception e
+                (log/log :error :webhook-failed hashed-req)
+                (.printStackTrace e))))))
+      (log/log :info :sleep sleep-time :webhook-done hashed-req :condition condition))
+
+    body))

--- a/test/com/moclojer/aux/samples.clj
+++ b/test/com/moclojer/aux/samples.clj
@@ -28,7 +28,6 @@
                              :body    {:id 1 :name "chico"}}
                :router-name :get-pet-by-id}}])
 
-
 (defonce *http-state (atom nil))
 
 (defn sample-upload-server

--- a/test/com/moclojer/edn_test.clj
+++ b/test/com/moclojer/edn_test.clj
@@ -5,7 +5,6 @@
             [com.moclojer.helpers-test :as helpers]
             [io.pedestal.test :refer [response-for]]))
 
-
 (deftest dynamic-endpoint-edn
   (let [service-fn (helpers/service-fn (edn/read-string (str "[" (slurp "test/com/moclojer/resources/moclojer.edn") "]")))]
     (testing "get all pets"

--- a/test/com/moclojer/log_test.clj
+++ b/test/com/moclojer/log_test.clj
@@ -11,10 +11,10 @@
             :msg "testing"
             :hello "moclojer"}
            (select-keys
-             (-> (log/log :info :testing :hello :moclojer)
-                 with-out-str
-                 (json/read-str :key-fn keyword))
-             [:msg :hello :level])))))
+            (-> (log/log :info :testing :hello :moclojer)
+                with-out-str
+                (json/read-str :key-fn keyword))
+            [:msg :hello :level])))))
 
 (deftest default-format-logging-test
   (testing "stdout content is formatted as default (println)"

--- a/test/com/moclojer/server_test.clj
+++ b/test/com/moclojer/server_test.clj
@@ -82,12 +82,11 @@
              (response-for :get "/v1/hello")
              :body
              (json/parse-string true))))
-   (is (= {:hello-v1 "hello world!"}
+  (is (= {:hello-v1 "hello world!"}
          (-> (helpers/service-fn (yaml/from-file "test/com/moclojer/resources/moclojer.yml"))
              (response-for :get "/v1/hello/")
              :body
              (json/parse-string true)))))
-
 
 (deftest multi-path-param
   (is (= {:username "moclojer-123"
@@ -103,7 +102,7 @@
              (response-for :get "/helloo/moclojer")
              :status)))
   (is (string/includes?
-        (-> (helpers/service-fn (yaml/from-file "test/com/moclojer/resources/mock-syntax-error.yml"))
-            (response-for :get "/helloo/moclojer")
-            :body)
-        "error")))
+       (-> (helpers/service-fn (yaml/from-file "test/com/moclojer/resources/mock-syntax-error.yml"))
+           (response-for :get "/helloo/moclojer")
+           :body)
+       "error")))

--- a/test/com/moclojer/webhook_test.clj
+++ b/test/com/moclojer/webhook_test.clj
@@ -1,10 +1,11 @@
 (ns com.moclojer.webhook-test
-  (:require [cheshire.core :as json]
-            [clojure.test :refer [deftest is]]
-            [com.moclojer.helpers-test :as helpers]
-            [com.moclojer.webhook :as webhook]
-            [io.pedestal.test :refer [response-for]]
-            [yaml.core :as yaml]))
+  (:require
+   [cheshire.core :as json]
+   [clojure.test :refer [deftest is]]
+   [com.moclojer.helpers-test :as helpers]
+   [com.moclojer.webhook :as webhook]
+   [io.pedestal.test :refer [response-for]]
+   [yaml.core :as yaml]))
 
 (def body {:id 123})
 


### PR DESCRIPTION
fixes https://github.com/moclojer/moclojer/issues/263

@avelino turns out it was the body that wasn't being parsed correctly.

Selmer, one of our dependencies, parses the body in a really specific way, and by not placing `safe` on evaluations, it will parse it correctly.

Now, we read these correctly, and try to parse back to json, in order to send the request correctly.

By putting `safe` on evaluations, I mean:

```yaml
    webhook:
      sleep-time: 0
      url: https://discord.com/api/webhooks/xxx/yyy/github
      method: POST
      body: "{{json-params|safe}}"
```

just using {{json-params}}, selmer would escape every quote or double quote as the urlsafe way, &quot;.

This imposes the enduser to place `safe` in order for things to work out. However, that wouldn't be straightfoward, right?. Do you think we should enforce `safe` ourselves when preprocessing the request body? This way the user wouldn't need to do it everytime.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a new helper function for parsing body strings from EDN format to JSON, enhancing error handling during parsing.
	- Simplified the `request-after-delay` function's signature for better flexibility and default handling.

- **Bug Fixes**
	- Improved logging within the `request-after-delay` function for better traceability of requests and errors.

- **Style**
	- Enhanced formatting and readability of multiple files, including alignment and whitespace adjustments in configuration and test files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->