### PR TITLE
Using webhook headers on its requests by default

### DIFF
--- a/docs/releases/v0.3.3.1.md
+++ b/docs/releases/v0.3.3.1.md
@@ -5,6 +5,7 @@
 ## What's Changed
 
 * Load parsed body correctly [PR #269](https://github.com/moclojer/moclojer/pull/269#pullrequestreview-2249011465)
+* Using webhook headers on its requests by default [PR #270](https://github.com/moclojer/moclojer/pull/272)
 
 ## Contributors
 

--- a/src/com/moclojer/specs/moclojer.clj
+++ b/src/com/moclojer/specs/moclojer.clj
@@ -1,5 +1,6 @@
 (ns com.moclojer.specs.moclojer
   (:require
+   [clojure.data.json :as json]
    [clojure.string :as string]
    [com.moclojer.external-body.core :as ext-body]
    [com.moclojer.webhook :as webhook]
@@ -46,7 +47,15 @@
         :condition (webhook-condition (:if webhook-config) request)
         :method (:method webhook-config)
         :body (render-template (:body webhook-config) request)
-        :headers (:headers webhook-config)
+        :headers (or (json/read-str
+                      (render-template
+                       (reduce-kv
+                        (fn [acc k v]
+                          (assoc acc k (string/lower-case v)))
+                        {}
+                        (:headers webhook-config))
+                       request))
+                     (:headers request))
         :sleep-time (:sleep-time webhook-config)}))
     {:body    (build-body response request)
      :status  (:status response)


### PR DESCRIPTION
closes #263

Complements #269. Both the body and the headers weren't being correctly parsed. This puts an end to this problem (I hope so).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced handling of HTTP headers in webhook processing.
	- Implemented automatic conversion of header values to lowercase for consistency.
	- Added a fallback mechanism to use incoming request headers if configured headers are missing.
	- Introduced default behavior for including webhook headers in all requests for improved integration.

- **Bug Fixes**
	- Improved robustness of webhook handling to ensure reliable header processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->