### PR TITLE
feat(middleware): add rate limit and latency middleware

### DIFF
--- a/src/com/moclojer/middleware/latency.clj
+++ b/src/com/moclojer/middleware/latency.clj
@@ -1,0 +1,41 @@
+(ns com.moclojer.middleware.latency
+  (:require [com.moclojer.log :as log]))
+
+(defn wrap-latency
+  "Simulates network latency and failures.
+   Options can be configured via endpoint metadata:
+   {:latency {:min-ms 100          ;; minimum latency in ms
+              :max-ms 1000         ;; maximum latency in ms
+              :failure-rate 0.01   ;; probability of 500 error
+              :timeout-rate 0.005  ;; probability of timeout
+              :timeout-ms 30000}}" ;; timeout duration
+  [handler]
+  (fn [request]
+    (let [{:keys [min-ms max-ms failure-rate timeout-rate timeout-ms]
+           :or {min-ms 0
+                max-ms 0
+                failure-rate 0
+                timeout-rate 0
+                timeout-ms 30000}} (get-in request [:reitit.core/match :data :latency])]
+
+      (when (pos? failure-rate)
+        (when (< (rand) failure-rate)
+          (log/log :debug :simulated-failure)
+          (throw (ex-info "Simulated failure"
+                          {:status 500
+                           :body {:error "Internal Server Error (simulated)"}}))))
+
+      (when (pos? timeout-rate)
+        (when (< (rand) timeout-rate)
+          (log/log :debug :simulated-timeout)
+          (Thread/sleep timeout-ms)
+          (throw (ex-info "Simulated timeout"
+                          {:status 504
+                           :body {:error "Gateway Timeout (simulated)"}}))))
+
+      (when (pos? max-ms)
+        (let [latency (+ min-ms (rand-int (- max-ms min-ms)))]
+          (log/log :debug :adding-latency :ms latency)
+          (Thread/sleep latency)))
+
+      (handler request))))

--- a/src/com/moclojer/middleware/rate_limit.clj
+++ b/src/com/moclojer/middleware/rate_limit.clj
@@ -1,0 +1,40 @@
+(ns com.moclojer.middleware.rate-limit
+  (:require [com.moclojer.log :as log]))
+
+(def ^:private requests-store (atom {}))
+
+(defn- cleanup-old-requests [requests window-ms now]
+  (let [cutoff (- now window-ms)]
+    (filterv #(>= % cutoff) requests)))
+
+(defn wrap-rate-limit
+  "Rate limiting middleware that limits requests by IP or custom key.
+   Options can be configured via endpoint metadata:
+   {:rate-limit {:window-ms 900000    ;; 15 minutes
+                 :max-requests 100     ;; requests per window
+                 :key-fn :remote-addr  ;; function to extract key from request}}"
+  [handler & {:keys [now-fn] :or {now-fn #(System/currentTimeMillis)}}]
+  (fn [request]
+    (let [{:keys [window-ms max-requests key-fn]
+           :or {window-ms (* 15 60 1000)
+                max-requests 100
+                key-fn :remote-addr}} (get-in request [:reitit.core/match :data :rate-limit])
+          now (now-fn)
+          req-key (key-fn request)
+          current-requests (get @requests-store req-key [])
+          valid-requests (cleanup-old-requests current-requests window-ms now)]
+
+      (if (>= (count valid-requests) max-requests)
+        (do
+          (log/log :warn :rate-limit-exceeded :key req-key)
+          {:status 429
+           :headers {"X-RateLimit-Limit" (str max-requests)
+                    "X-RateLimit-Remaining" "0"
+                    "X-RateLimit-Reset" (str (+ now window-ms))}
+           :body {:error "Rate limit exceeded"}})
+        (let [updated-requests (conj (vec (sort valid-requests)) now)]
+          (swap! requests-store assoc req-key updated-requests)
+          (-> (handler request)
+              (update :headers merge
+                      {"X-RateLimit-Limit" (str max-requests)
+                       "X-RateLimit-Remaining" (str (- max-requests (count updated-requests)))})))))))

--- a/src/com/moclojer/server.clj
+++ b/src/com/moclojer/server.clj
@@ -18,7 +18,9 @@
    [reitit.ring.middleware.parameters :as parameters]
    [reitit.swagger :as swagger]
    [reitit.swagger-ui :as swagger-ui]
-   [ring.adapter.jetty :as jetty]))
+   [ring.adapter.jetty :as jetty]
+   [com.moclojer.middleware.rate-limit :as rate-limit]
+   [com.moclojer.middleware.latency :as latency]))
 
 (defn host-middleware
   [handler-fn]
@@ -52,6 +54,8 @@
             :middleware [host-middleware
                          log/log-request-middleware
                          swagger/swagger-feature
+                         rate-limit/wrap-rate-limit
+                         latency/wrap-latency
                          parameters/parameters-middleware
                          muuntaja/format-negotiate-middleware
                          muuntaja/format-response-middleware

--- a/test/com/moclojer/middleware/latency_test.clj
+++ b/test/com/moclojer/middleware/latency_test.clj
@@ -1,0 +1,60 @@
+(ns com.moclojer.middleware.latency-test
+  (:require [clojure.test :refer [deftest testing is]]
+            [com.moclojer.middleware.latency :as latency]))
+
+(deftest wrap-latency-test
+  (testing "Basic latency simulation"
+    (let [handler (fn [_] {:status 200 :body "OK"})
+          wrapped-handler (latency/wrap-latency handler)
+          request {:reitit.core/match
+                  {:data {:latency {:min-ms 50
+                                  :max-ms 100}}}}
+          start-time (System/currentTimeMillis)
+          response (wrapped-handler request)
+          elapsed-time (- (System/currentTimeMillis) start-time)]
+
+      (is (= 200 (:status response)))
+      (is (<= 50 elapsed-time 100))))
+
+  (testing "Failure simulation"
+    (let [handler (fn [_] {:status 200 :body "OK"})
+          wrapped-handler (latency/wrap-latency handler)
+          request {:reitit.core/match
+                  {:data {:latency {:failure-rate 1.0}}}}] ;; Always fail
+
+      (try
+        (wrapped-handler request)
+        (is false "Should have thrown an exception")
+        (catch clojure.lang.ExceptionInfo e
+          (is (= 500 (:status (ex-data e))))
+          (is (= "Internal Server Error (simulated)"
+                 (get-in (ex-data e) [:body :error])))))))
+
+  (testing "Timeout simulation"
+    (let [handler (fn [_] {:status 200 :body "OK"})
+          wrapped-handler (latency/wrap-latency handler)
+          request {:reitit.core/match
+                  {:data {:latency {:timeout-rate 1.0  ;; Always timeout
+                                  :timeout-ms 100}}}}
+          start-time (System/currentTimeMillis)]
+
+      (try
+        (wrapped-handler request)
+        (is false "Should have thrown an exception")
+        (catch clojure.lang.ExceptionInfo e
+          (let [elapsed-time (- (System/currentTimeMillis) start-time)]
+            (is (= 504 (:status (ex-data e))))
+            (is (= "Gateway Timeout (simulated)"
+                   (get-in (ex-data e) [:body :error])))
+            (is (<= 100 elapsed-time)))))))
+
+  (testing "No latency when not configured"
+    (let [handler (fn [_] {:status 200 :body "OK"})
+          wrapped-handler (latency/wrap-latency handler)
+          request {:reitit.core/match {:data {}}}
+          start-time (System/currentTimeMillis)
+          response (wrapped-handler request)
+          elapsed-time (- (System/currentTimeMillis) start-time)]
+
+      (is (= 200 (:status response)))
+      (is (< elapsed-time 50) "Should not add significant latency"))))

--- a/test/com/moclojer/middleware/rate_limit_test.clj
+++ b/test/com/moclojer/middleware/rate_limit_test.clj
@@ -1,0 +1,52 @@
+(ns com.moclojer.middleware.rate-limit-test
+  (:require [clojure.test :refer [deftest testing is use-fixtures]]
+            [com.moclojer.middleware.rate-limit :as rate-limit]))
+
+;; Reset the store before each test
+(use-fixtures :each
+  (fn [f]
+    (reset! @#'rate-limit/requests-store {})
+    (f)))
+
+(deftest wrap-rate-limit-test
+  (testing "Basic rate limiting"
+    (let [handler (fn [_] {:status 200 :body "OK"})
+          wrapped-handler (rate-limit/wrap-rate-limit handler)
+          request {:reitit.core/match
+                   {:data {:rate-limit {:window-ms 1000
+                                        :max-requests 2
+                                        :key-fn (constantly "test-key")}}}}]
+
+      ;; First request should pass
+      (let [response (wrapped-handler request)]
+        (is (= 200 (:status response)))
+        (is (= "2" (get-in response [:headers "X-RateLimit-Limit"])))
+        (is (= "1" (get-in response [:headers "X-RateLimit-Remaining"]))))
+
+      ;; Second request should pass
+      (let [response (wrapped-handler request)]
+        (is (= 200 (:status response)))
+        (is (= "0" (get-in response [:headers "X-RateLimit-Remaining"]))))
+
+      ;; Third request should be blocked
+      (let [response (wrapped-handler request)]
+        (is (= 429 (:status response)))
+        (is (= "Rate limit exceeded" (get-in response [:body :error]))))))
+
+  (testing "Different keys should have separate limits"
+    (let [handler (fn [_] {:status 200 :body "OK"})
+          wrapped-handler (rate-limit/wrap-rate-limit handler)
+          make-request #(hash-map :reitit.core/match
+                                  {:data {:rate-limit {:window-ms 1000
+                                                       :max-requests 1
+                                                       :key-fn :key}}}
+                                  :key %)]
+
+      ;; Request from key1 should pass
+      (is (= 200 (:status (wrapped-handler (make-request "key1")))))
+
+      ;; Request from key2 should pass
+      (is (= 200 (:status (wrapped-handler (make-request "key2")))))
+
+      ;; Second request from key1 should be blocked
+      (is (= 429 (:status (wrapped-handler (make-request "key1"))))))))


### PR DESCRIPTION
Add rate limiting and latency simulation middleware to enhance API behavior control:

- Rate limiting middleware:
  - Configurable request limits per time window
  - Custom key functions for limit grouping
  - Rate limit headers (`X-RateLimit-*`)
  - 429 status code when limit exceeded

- Latency middleware:
  - Simulated network delays (min/max ms)
  - Configurable failure rates
  - Timeout simulation
  - Customizable per endpoint

fixed: #301