### PR TITLE
fix: --mocks tag not working

### DIFF
--- a/src/com/moclojer/router.clj
+++ b/src/com/moclojer/router.clj
@@ -22,8 +22,10 @@
   See also: `com.moclojer.adapters`."
   [{:keys [::config ::mocks]}]
   (let [mode (if mocks :openapi :moclojer)
-        routes (if mocks
-                 (openapi/->moclojer config mocks)
+        routes (if (seq mocks)
+                 (if (vector? mocks)
+                   mocks
+                   (openapi/->moclojer config mocks))
                  config)]
 
     (log/log :info :spec-mode :mode mode)


### PR DESCRIPTION
fixes #299 

After trying to reproduce the bug, it showed that the `--mocks` tag was able to catch the file, but was trying to format twice when called with the tag. This change verifies if _mocks_ is already a vector before trying to format again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enhanced routing behavior to ensure consistent processing of configuration inputs. The system now supports direct handling of list-formatted inputs while maintaining standard behavior for other cases, improving flexibility and overall reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->